### PR TITLE
Add `__version__` to top-level package.

### DIFF
--- a/google/generativeai/__init__.py
+++ b/google/generativeai/__init__.py
@@ -53,6 +53,7 @@ for model in genai.list_models():
 """
 
 from google.generativeai import types
+from google.generativeai import version
 
 from google.generativeai.discuss import chat
 from google.generativeai.discuss import chat_async
@@ -64,10 +65,12 @@ from google.generativeai.text import generate_embeddings
 from google.generativeai.models import list_models
 from google.generativeai.models import get_model
 
-
 from google.generativeai.client import configure
+
+__version__ = version.__version__
 
 del discuss
 del text
 del models
 del client
+del version


### PR DESCRIPTION
I think this is pretty conventional. Users should be able to:

```python
import google.generativeai as palm
print(palm.__version__)`
```

Change-Id: Ide7299f3a4d7a9017cf05fa42d78126a5c4bacf7