### PR TITLE
Fix: indexError for `[]` `candidates`

### DIFF
--- a/google/generativeai/discuss.py
+++ b/google/generativeai/discuss.py
@@ -440,7 +440,7 @@ def _build_chat_response(
     request["messages"] = prompt["messages"]
 
     response = type(response).to_dict(response)
-    request["messages"].append(response["candidates"][0])
+    request["messages"].extend(response.get("candidates", [])[:1])
     request.setdefault("temperature", None)
     request.setdefault("candidate_count", None)
 


### PR DESCRIPTION
This PR fixes the `indexError` but not the root cause.

For cases where `candidates` are `[]` we end up with `IndexError: list index out of range` maybe it is a limitation of bison?  Should we show a default error message?

For the below input we always get an `indexError`:

__input:__ 
`Can you fetch from URL?`

__output:__
```py
{'messages': [{'author': '0', 'content': 'Can you fetch from URL?'}], 'candidates': []}
```