### PR TITLE
Drop python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,16 +77,15 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",  # Colab
         "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.10", # Colab
         "Programming Language :: Python :: 3.11",
         "Operating System :: OS Independent",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
     platforms="Posix; MacOS X; Windows",
     packages=packages,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     namespace_packages=namespaces,
     install_requires=dependencies,
     extras_require=extras_require,


### PR DESCRIPTION
Python 3.8 was included for Colab, and that's how we were testing it. 3.8 is in end-of-life-secutrity-patches-only mode. Colab has moved to 3.10.

For: https://github.com/google/generative-ai-python/issues/13