### PR TITLE
Fix errors caused by setting ChatResponse.last

### DIFF
--- a/google/generativeai/discuss.py
+++ b/google/generativeai/discuss.py
@@ -399,6 +399,7 @@ class ChatResponse(discuss_types.ChatResponse):
     @last.setter
     def last(self, message: discuss_types.MessageOptions):
         message = _make_message(message)
+        message = type(message).to_dict(message)
         self.messages[-1] = message
 
     @set_doc(discuss_types.ChatResponse.reply.__doc__)

--- a/tests/test_discuss.py
+++ b/tests/test_discuss.py
@@ -344,6 +344,13 @@ class UnitTests(parameterized.TestCase):
         )
         self.assertLen(response.messages, 4)
 
+    def test_set_last(self):
+        response = discuss.chat(messages="Can you overwrite `.last`?")
+        response.last = 'yes'
+        response = response.reply('glad to hear it!')
+        response.last = "Me too!"
+        self.assertEqual([msg['content'] for msg in response.messages],
+                         ["Can you overwrite `.last`?", 'yes', 'glad to hear it!', 'Me too!'])
 
 if __name__ == "__main__":
     absltest.main()


### PR DESCRIPTION
The created message should be a `dict`.