### PR TITLE
Try to fix mystery string interpolation

### DIFF
--- a/google/generativeai/discuss.py
+++ b/google/generativeai/discuss.py
@@ -93,9 +93,9 @@ def _make_examples_from_flat(
     if len(examples) % 2 != 0:
         raise ValueError(
             textwrap.dedent(
-                """\
+                f"""\
             You must pass `Primer` objects, pairs of messages, or an *even* number of messages, got: 
-              {len(primers)} messages"""
+              {len(examples)} messages"""
             )
         )
     result = []


### PR DESCRIPTION
This PR tries to fix a mystery string interpolation when the number of `examples` is odd when using `chat`.

Before the fix:
```
ValueError: You must pass `Primer` objects, pairs of messages, or an *even* number of messages, got: 
  {len(primers)} messages
```

After the fix:
```
ValueError: You must pass `Primer` objects, pairs of messages, or an *even* number of messages, got: 
  1 messages
```