### PR TITLE
Add Python support to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Google Generative AI Python Client
 ==================================
 
 [![PyPI version](https://badge.fury.io/py/google-generativeai.svg)](https://badge.fury.io/py/google-generativeai)
+![Python support](https://img.shields.io/pypi/pyversions/google-generativeai)
 ![PyPI - Downloads](https://img.shields.io/pypi/dd/google-generativeai)
 
 Get started using the PaLM API in Python. Check out the [developer site](https://developers.generativeai.google/)


### PR DESCRIPTION
In https://github.com/google/generative-ai-docs/issues/63 the user pointed out that we don't document Python support.

This badge uses the latest PyPI package, so should be future-proof as we move things around.