### PR TITLE
Adding github action workflow to mark stale issues and prs.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
+  # Scheduled to run at 1.30 UTC everyday
   - cron: '30 1 * * *'
 
 jobs:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -40,7 +40,7 @@ jobs:
           This PR will be closed if no further activity occurs.
         close-pr-message: >
           This pull request was closed because it has been inactive for 28 days.
-          Please post a new issue if you need further assistance. Thanks!
+          Please open a new pull request if you need further assistance. Thanks!
         # Label that can be assigned to issues to exclude them from being marked as stale
         exempt-issue-labels: 'override-stale'
         # Label that can be assigned to PRs to exclude them from being marked as stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,48 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '30 1 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-issue-stale: 14
+        days-before-issue-close: 14
+        stale-issue-label: "stale"
+        close-issue-reason: completed
+        any-of-labels: "status:awaiting user response,status:more data needed"
+        stale-issue-message: >
+          Marking this issue as stale since it has been open for 14 days with no activity.
+          This issue will be closed if no further activity occurs.
+        close-issue-message: >
+          This issue was closed because it has been inactive for 28 days.
+          Please post a new issue if you need further assistance. Thanks!
+        days-before-pr-stale: 14
+        days-before-pr-close: 14
+        stale-pr-label: "stale"
+        stale-pr-message: >
+          Marking this pull request as stale since it has been open for 14 days with no activity.
+          This PR will be closed if no further activity occurs.
+        close-pr-message: >
+          This pull request was closed because it has been inactive for 28 days.
+          Please post a new issue if you need further assistance. Thanks!
+        # Label that can be assigned to issues to exclude them from being marked as stale
+        exempt-issue-labels: 'override-stale'
+        # Label that can be assigned to PRs to exclude them from being marked as stale
+        exempt-pr-labels: "override-stale"
+        


### PR DESCRIPTION
Adding github action workflow to mark stale issues and prs. This stale management workflow will add stale label and post reminder message after 14 days of inactivity and further close issue/pr after another 14 days of inactivity. We can also override stale action by adding override-stale label. Thanks! cc @google/gtech-llm-support