### PR TITLE
Add basic editor configs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# 4 space indentation
+[*.py]
+charset = utf-8
+indent_style = space
+indent_size = 4
+max_line_length = 100

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.egg-info
 .DS_Store
 __pycache__
+*.iml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.pytype]
 inputs = ['google', 'tests']
+
+[tool.black]
+line-length = 100


### PR DESCRIPTION
These are helpful for persisting style preferences across IDEs & tools. e.g. by default PyCharm likes to follow PEP8, so dumps a *heap* of errors.

Also ignore idea project files.