### PR TITLE
Update gspread_client.py

### DIFF
--- a/google/generativeai/notebook/gspread_client.py
+++ b/google/generativeai/notebook/gspread_client.py
@@ -29,14 +29,10 @@ from google.generativeai.notebook import sheets_id
 _gspread_import_error: Exception | None = None
 try:
     # pylint: disable-next=g-import-not-at-top
-    from gspread import gspread
-except (ImportError, ModuleNotFoundError):
-    try:
-        # pylint: disable-next=g-import-not-at-top
-        import gspread
-    except ImportError as e:
-        _gspread_import_error = e
-        gspread = None
+    import gspread
+except ImportError as e:
+    _gspread_import_error = e
+    gspread = None
 
 # Base class of exceptions that  gspread.open(), open_by_url() and open_by_key()
 # may throw.


### PR DESCRIPTION
Inside google, we  are removing support for `from gspread import gspread`

## Description of the change
remove support for `from gspread import gspread`

## Motivation
When gspread is installed through pip, it can be used as `import gspread`

## Type of change
Choose one: Bug fix

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about). 
I am already a Googler so I don't need to sign the CLA as the CLA text says.
