### PR TITLE
Restore ModelNameOptions for backwards compatibility.

### DIFF
--- a/google/generativeai/types/model_types.py
+++ b/google/generativeai/types/model_types.py
@@ -25,6 +25,7 @@ from google.generativeai import string_utils
 
 __all__ = [
     "Model",
+    "ModelNameOptions",
     "AnyModelNameOptions",
     "BaseModelNameOptions",
     "TunedModelNameOptions",
@@ -232,6 +233,7 @@ class Hyperparameters:
 BaseModelNameOptions = Union[str, Model, glm.Model]
 TunedModelNameOptions = Union[str, TunedModel, glm.TunedModel]
 AnyModelNameOptions = Union[str, Model, glm.Model, TunedModel, glm.TunedModel]
+ModelNameOptions = AnyModelNameOptions
 
 
 def make_model_name(name: AnyModelNameOptions):


### PR DESCRIPTION
Revert accidental change to the public api-surface:.