### PR TITLE
Support specific tabs when loading Google Sheets

### DIFF
--- a/google/generativeai/types/model_types.py
+++ b/google/generativeai/types/model_types.py
@@ -213,7 +213,7 @@ def encode_tuning_data(
 
     if isinstance(data, str):
         # Strings are either URLs or system paths.
-        if re.match("^\w+://\S+$", data):
+        if re.match(r"^\w+://\S+$", data):
             data = _normalize_url(data)
         else:
             # Normalize system paths to use pathlib
@@ -246,10 +246,17 @@ def _normalize_url(url: str) -> str:
     sheet_base = "https://docs.google.com/spreadsheets"
     if url.startswith(sheet_base):
         # Normalize google-sheets URLs to download the csv.
-        match = re.match(f"{sheet_base}/d/[^/]+", url)
-        if match is None:
+        id_match = re.match(f"{sheet_base}/d/[^/]+", url)
+        if id_match is None:
             raise ValueError("Incomplete Google Sheets URL: {data}")
-        url = f"{match.group(0)}/export?format=csv"
+
+        if tab_match := re.search(r"gid=(\d+)", url):
+            tab_param = f"&gid={tab_match.group(1)}"
+        else:
+            tab_param = ""
+
+        url = f"{id_match.group(0)}/export?format=csv{tab_param}"
+
     return url
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -448,6 +448,10 @@ class UnitTests(parameterized.TestCase):
             "sheet-export-csv",
             "https://docs.google.com/spreadsheets/d/1OffcVSqN6X-RYdWLGccDF3KtnKoIpS7O_9cZbicKK4A/export?format=csv",
         ],
+        [
+            "sheet-with-tab",
+            "https://docs.google.com/spreadsheets/d/118LXTS3RIkS4yAO68c-cMPP4PwLFTxKYj4R43R7dU0E/edit#gid=1526779134",
+        ],
     )
     def test_create_dataset(self, data, ik="text_input", ok="output"):
         ds = model_types.encode_tuning_data(data, input_key=ik, output_key=ok)


### PR DESCRIPTION
## Description of the change
Add support for tabs when loading Sheets URLs

## Motivation
CSV URL supports it, and silently dropping the tab seems less than ideal, so this seems like an easy fix.

## Type of change
Choose one: Bug fix | Feature request

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
