### PR TITLE
fixed a possible json typo with "uri" instead of "url"

### DIFF
--- a/google/generativeai/types/citation_types.py
+++ b/google/generativeai/types/citation_types.py
@@ -30,7 +30,7 @@ __all__ = [
 class CitationSourceDict(TypedDict):
     start_index: int | None
     end_index: int | None
-    uri: str | None
+    url: str | None
     license: str | None
 
     __doc__ = string_utils.strip_oneof(glm.CitationSource.__doc__)

--- a/tests/test_discuss.py
+++ b/tests/test_discuss.py
@@ -326,7 +326,7 @@ class UnitTests(parameterized.TestCase):
                             {
                                 "start_index": 6,
                                 "end_index": 12,
-                                "uri": "https://google.com",
+                                "url": "https://google.com",
                             }
                         ]
                     },

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -391,7 +391,7 @@ class UnitTests(parameterized.TestCase):
                             {
                                 "start_index": 6,
                                 "end_index": 12,
-                                "uri": "https://google.com",
+                                "url": "https://google.com",
                             }
                         ]
                     },


### PR DESCRIPTION
## Description of the change
<!--- Describe your changes in detail. -->
The google.generativeai.discuss.ChatResponse object when returned gives {'citation_sources': [{'start_index': <int>, 'end_index': <int>, 'uri': <link>]}
And I believe it should be `url` and was a typo that was missed

## Motivation
<!--- Why is this change required? What problem does it solve? Please include the corresponding issue number/link if applicable. -->
![image](https://github.com/google/generative-ai-python/assets/85993243/107c8849-d748-4204-a435-01c3ac95bf23)
I was trying out the api, and found this interesting feature where the api also returned the proper citiation, but found out that there was a typo in the same, so just a pr to fix it.

## Type of change
Bug fix / Typo fix

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [X] I have performed a self-review of my code.
- [X] I have added detailed comments to my code where applicable.
- [X] I have verified that my change does not break existing code.
- [X] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [X] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [X] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
