### PR TITLE
Fix source URLs for `glm.*` members.

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -176,9 +176,7 @@ def gen_api_docs():
 
     doc_generator = MyDocGenerator(
         root_title=PROJECT_FULL_NAME,
-        # Replace `tensorflow_docs.api_generator` with your module, here.
         py_modules=[("google", google)],
-        # Replace `tensorflow_docs.api_generator` with your module, here.
         base_dir=(
             pathlib.Path(palm.__file__).parent,
             pathlib.Path(glm.__file__).parent.parent,
@@ -223,7 +221,7 @@ def gen_api_docs():
         new_content = re.sub(r".*?`oneof`_ ``_.*?\n", "", new_content, re.MULTILINE)
         new_content = re.sub(r"\.\. code-block:: python.*?\n", "", new_content)
 
-        new_content = re.sub(r"generativelanguage_\w+.types", "generativelanguage", new_content)
+        new_content = re.sub(r"generativelanguage_\w+\.types", "generativelanguage", new_content)
 
         if new_content != old_content:
             fpath.write_text(new_content)


### PR DESCRIPTION
GLAPI members defined in a versioned package (e.g. `v1beta3`) were generating an incorrect URL for the "view on github" link.

To test the regex I ran it on a suspended instance of the script:

```
diff -u <(egrep -Iir 'generativelanguage_\w+\.types' docs/api/google/ai/generativelanguage/ --include=*.md) \
        <(egrep -Iir 'generativelanguage_\w+.types' docs/api/google/ai/generativelanguage/ --include=*.md)
```

Output [here](http://go/paste/6300090913259520), but it only matched `<a href />`s.


## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
