### PR TITLE
fix TypeError in count_tokens & count_tokens_async

### DIFF
--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -275,13 +275,13 @@ class GenerativeModel:
         self, contents: content_types.ContentsType
     ) -> glm.CountTokensResponse:
         contents = content_types.to_contents(contents)
-        return self._client.count_tokens(self.model_name, contents)
+        return self._client.count_tokens(model=self.model_name, contents=contents)
 
     async def count_tokens_async(
         self, contents: content_types.ContentsType
     ) -> glm.CountTokensResponse:
         contents = content_types.to_contents(contents)
-        return await self._client.count_tokens(self.model_name, contents)
+        return await self._client.count_tokens(model=self.model_name, contents=contents)
     # fmt: on
 
     def start_chat(


### PR DESCRIPTION
`async def count_tokens(
        self,
        request: Optional[Union[generative_service.CountTokensRequest, dict]] = None,
        *,
        model: Optional[str] = None,
        contents: Optional[MutableSequence[content.Content]] = None,
        retry: OptionalRetry = gapic_v1.method.DEFAULT,
        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
        metadata: Sequence[Tuple[str, str]] = (),
`
    if you don't use keyword args : model=model, contents=contents,  but position args, this will lead to : TypeError: count_tokens() takes from 1 to 2 positional arguments but 3 were given
## Description of the change
<!--- Describe your changes in detail. -->

## Motivation
<!--- Why is this change required? What problem does it solve? Please include the corresponding issue number/link if applicable. -->

## Type of change
Choose one: (Bug fix | Feature request | Documentation | Other)

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x ] I have performed a self-review of my code.
- [x ] I have added detailed comments to my code where applicable.
- [x ] I have verified that my change does not break existing code.
- [x ] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x ] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x ] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
