### PR TITLE
Fix Javscript -> Python typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ documentation: https://ai.google.dev/docs
 
 ## Contributing
 
-See [Contributing](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) for more information on contributing to the Google AI JavaScript SDK.
+See [Contributing](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) for more information on contributing to the Google AI Python SDK.
 
 ## Developers who use the PaLM API
 


### PR DESCRIPTION
## Description of the change
Fix `Javascript` typo to `Python` in README.md

## Motivation
Avoids confusion in the README since this is the Python SDK. 

## Type of change
Documentation

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
