### PR TITLE
fix: handle empty string in ChatSession.send_message

### DIFF
--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -346,6 +346,8 @@ class ChatSession:
         stream: bool = False,
         **kwargs,
     ) -> generation_types.GenerateContentResponse:
+        if not contents:
+            raise TypeError("contents must not be empty")
         content = content_types.to_content(content)
         if not content.role:
             content.role = self._USER_ROLE

--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -346,8 +346,6 @@ class ChatSession:
         stream: bool = False,
         **kwargs,
     ) -> generation_types.GenerateContentResponse:
-        if not contents:
-            raise TypeError("contents must not be empty")
         content = content_types.to_content(content)
         if not content.role:
             content.role = self._USER_ROLE

--- a/google/generativeai/types/content_types.py
+++ b/google/generativeai/types/content_types.py
@@ -189,6 +189,9 @@ StrictContentType = Union[glm.Content, ContentDict]
 
 
 def to_content(content: ContentType):
+    if not content:
+        raise TypeError("content must not be empty")
+
     if isinstance(content, Mapping):
         content = _convert_dict(content)
 

--- a/google/generativeai/types/content_types.py
+++ b/google/generativeai/types/content_types.py
@@ -190,7 +190,7 @@ StrictContentType = Union[glm.Content, ContentDict]
 
 def to_content(content: ContentType):
     if not content:
-        raise TypeError("content must not be empty")
+        raise ValueError("content must not be empty")
 
     if isinstance(content, Mapping):
         content = _convert_dict(content)


### PR DESCRIPTION
## Description of the change
<!--- Describe your changes in detail. -->
Update  `ChatSession.send_message` to  check for empty `contents`. If `contents` is  empty a `TypeError` (Same behavior as `GenerativeModel.generate_content`)
## Motivation
<!--- Why is this change required? What problem does it solve? Please include the corresponding issue number/link if applicable. -->
Fixing issue : #133 

## Type of change
Choose one: Bug fix

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [X] I have performed a self-review of my code.
- [X] I have added detailed comments to my code where applicable.
- [X] I have verified that my change does not break existing code.
- [X] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [ ] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [X] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
