### PR TITLE
Fix build docs.

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -26,15 +26,16 @@ import re
 import textwrap
 import typing
 
-# For showing the conditional imports and types in `content_types.py`
-typing.TYPE_CHECKING = True
 
 from absl import app
 from absl import flags
 
 import google
-from google import generativeai as palm
 from google.ai import generativelanguage as glm
+
+# For showing the conditional imports and types in `content_types.py`
+typing.TYPE_CHECKING = True
+from google import generativeai as palm
 
 from tensorflow_docs.api_generator import generate_lib
 from tensorflow_docs.api_generator import public_api

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -33,9 +33,13 @@ from absl import flags
 import google
 from google.ai import generativelanguage as glm
 
+import grpc 
 # For showing the conditional imports and types in `content_types.py`
+# grpc must be imported first.
 typing.TYPE_CHECKING = True
 from google import generativeai as palm
+
+
 
 from tensorflow_docs.api_generator import generate_lib
 from tensorflow_docs.api_generator import public_api


### PR DESCRIPTION
GRPC has a circular import that's skipped by the typing flag. Move imports to make the build pass.

in grpc/_typing.py:

```
if TYPE_CHECKING:
    from grpc import ServicerContext
    from grpc._server import _RPCState
```