### PR TITLE
More readable error message

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -33,12 +33,12 @@ from absl import flags
 import google
 from google.ai import generativelanguage as glm
 
-import grpc 
+import grpc
+
 # For showing the conditional imports and types in `content_types.py`
 # grpc must be imported first.
 typing.TYPE_CHECKING = True
 from google import generativeai as palm
-
 
 
 from tensorflow_docs.api_generator import generate_lib

--- a/google/generativeai/types/generation_types.py
+++ b/google/generativeai/types/generation_types.py
@@ -327,7 +327,7 @@ class BaseGenerateContentResponse:
         if len(parts) != 1 or "text" not in parts[0]:
             raise ValueError(
                 "The `response.text` quick accessor only works for "
-                "simple (single-`Part`) text responses. This response is not simple text."
+                "simple (single-`Part`) text responses. This response is not simple text. "
                 "Use the `result.parts` accessor or the full "
                 "`result.candidates[index].content.parts` lookup "
                 "instead."


### PR DESCRIPTION
## Description of the change
<!--- Describe your changes in detail. -->
Error message style fix

## Motivation
<!--- Why is this change required? What problem does it solve? Please include the corresponding issue number/link if applicable. -->

Thank you very much for developing this great library.
I saw the error message

```
  File "/.../venv/lib/python3.11/site-packages/google/generativeai/types/generation_types.py", line 328, in text
    raise ValueError(
ValueError: The `response.text` quick accessor only works for simple (single-`Part`) text responses. This response is not simple text.Use the `result.parts` accessor or the full `result.candidates[index].content.parts` lookup instead.
```

and found `text.Use` (no space!)

## Type of change
Choose one: Other

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
