### PR TITLE
Add python 3.12 support.

### DIFF
--- a/.github/workflows/test_pr.yaml
+++ b/.github/workflows/test_pr.yaml
@@ -14,6 +14,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  test3_12:
+    name: Test Py3.12
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+    - name: Run tests
+      run: |
+        python --version
+        pip install .[dev]
+        python -m unittest
   test3_11:
     name: Test Py3.11
     runs-on: ubuntu-latest

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",  # Colab
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Operating System :: OS Independent",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],


### PR DESCRIPTION
## Description of the change

Enable testing with python 3.12

## Motivation

3.12 is the latest version of python and is now supported by the underlying GAPIC and auth libraries. 

https://devguide.python.org/versions/

## Type of change

Feature request

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x ] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
