### PR TITLE
Add a more explicit error when no `parts` returned

### DIFF
--- a/google/generativeai/embedding.py
+++ b/google/generativeai/embedding.py
@@ -93,8 +93,7 @@ def embed_content(
     task_type: EmbeddingTaskTypeOptions | None = None,
     title: str | None = None,
     client: glm.GenerativeServiceClient | None = None,
-) -> text_types.EmbeddingDict:
-    ...
+) -> text_types.EmbeddingDict: ...
 
 
 @overload
@@ -104,8 +103,7 @@ def embed_content(
     task_type: EmbeddingTaskTypeOptions | None = None,
     title: str | None = None,
     client: glm.GenerativeServiceClient | None = None,
-) -> text_types.BatchEmbeddingDict:
-    ...
+) -> text_types.BatchEmbeddingDict: ...
 
 
 def embed_content(

--- a/google/generativeai/notebook/lib/llmfn_outputs.py
+++ b/google/generativeai/notebook/lib/llmfn_outputs.py
@@ -109,12 +109,10 @@ class LLMFnOutputsBase(Sequence[LLMFnOutputEntry]):
 
     # Needed for Sequence[LLMFnOutputEntry].
     @overload
-    def __getitem__(self, x: int) -> LLMFnOutputEntry:
-        ...
+    def __getitem__(self, x: int) -> LLMFnOutputEntry: ...
 
     @overload
-    def __getitem__(self, x: slice) -> Sequence[LLMFnOutputEntry]:
-        ...
+    def __getitem__(self, x: slice) -> Sequence[LLMFnOutputEntry]: ...
 
     def __getitem__(self, x: int | slice) -> LLMFnOutputEntry | Sequence[LLMFnOutputEntry]:
         return self._outputs.__getitem__(x)

--- a/google/generativeai/notebook/magics_engine.py
+++ b/google/generativeai/notebook/magics_engine.py
@@ -61,9 +61,7 @@ class MagicsEngine:
     ) -> tuple[parsed_args_lib.ParsedArgs, parsed_args_lib.PostProcessingTokens]:
         return cmd_line_parser.CmdLineParser().parse_line(line, placeholders)
 
-    def _get_handler(
-        self, line: str, placeholders: AbstractSet[str]
-    ) -> tuple[
+    def _get_handler(self, line: str, placeholders: AbstractSet[str]) -> tuple[
         command.Command,
         parsed_args_lib.ParsedArgs,
         Sequence[post_process_utils.ParsedPostProcessExpr],

--- a/google/generativeai/text.py
+++ b/google/generativeai/text.py
@@ -263,8 +263,7 @@ def generate_embeddings(
     model: model_types.BaseModelNameOptions,
     text: str,
     client: glm.TextServiceClient = None,
-) -> text_types.EmbeddingDict:
-    ...
+) -> text_types.EmbeddingDict: ...
 
 
 @overload
@@ -272,8 +271,7 @@ def generate_embeddings(
     model: model_types.BaseModelNameOptions,
     text: Sequence[str],
     client: glm.TextServiceClient = None,
-) -> text_types.BatchEmbeddingDict:
-    ...
+) -> text_types.BatchEmbeddingDict: ...
 
 
 def generate_embeddings(

--- a/google/generativeai/types/generation_types.py
+++ b/google/generativeai/types/generation_types.py
@@ -324,6 +324,13 @@ class BaseGenerateContentResponse:
             ValueError: If the candidate list or parts list does not contain exactly one entry.
         """
         parts = self.parts
+        if not parts:
+            raise ValueError(
+                "The `response.text` quick accessor only works when the response contains a valid "
+                "`Part`, but none was returned. Check the `candidate.safety_ratings` to see if the "
+                "response was blocked."
+            )
+
         if len(parts) != 1 or "text" not in parts[0]:
             raise ValueError(
                 "The `response.text` quick accessor only works for "

--- a/google/generativeai/types/generation_types.py
+++ b/google/generativeai/types/generation_types.py
@@ -268,9 +268,11 @@ class BaseGenerateContentResponse:
     def __init__(
         self,
         done: bool,
-        iterator: None
-        | Iterable[glm.GenerateContentResponse]
-        | AsyncIterable[glm.GenerateContentResponse],
+        iterator: (
+            None
+            | Iterable[glm.GenerateContentResponse]
+            | AsyncIterable[glm.GenerateContentResponse]
+        ),
         result: glm.GenerateContentResponse,
         chunks: Iterable[glm.GenerateContentResponse],
     ):


### PR DESCRIPTION
When a response has been blocked, the API will return a `Candidate` (with `finish_reason`, `safety_ratings`, etc) that does not have any `Part`s.  Given blocking is common enough, and we can identify this case, I've added a more explicit (and helpful?) error message to guide users if this happens.

LMK (or just push) if you think this could be worded clearer.

This should also fix the `TypeError: argument of type 'Part' is not iterable` error thrown in another (unknown?) case.