### PR TITLE
Fix list methods, add decode functions.

### DIFF
--- a/google/generativeai/retriever.py
+++ b/google/generativeai/retriever.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import re
 import string
 import dataclasses
-from typing import Iterable, Optional
+from typing import AsyncIterable, Iterable, Optional
 
 import google.ai.generativelanguage as glm
 
@@ -203,7 +203,7 @@ async def list_corpora_async(
     *,
     page_size: Optional[int] = None,
     client: glm.RetrieverServiceClient | None = None,
-) -> Iterable[retriever_types.Corpus]:
+) -> AsyncIterable[retriever_types.Corpus]:
     """This is the async version of `retriever.list_corpora`."""
     if client is None:
         client = get_default_retriever_async_client()

--- a/google/generativeai/retriever.py
+++ b/google/generativeai/retriever.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import re
 import string
 import dataclasses
-from typing import Optional
+from typing import Iterable, Optional
 
 import google.ai.generativelanguage as glm
 

--- a/google/generativeai/retriever.py
+++ b/google/generativeai/retriever.py
@@ -213,12 +213,12 @@ async def list_corpora_async(
     *,
     page_size: Optional[int] = None,
     client: glm.RetrieverServiceClient | None = None,
-) -> list[Corpus]:
+) -> Iterable[retriever_types.Corpus]:
     """This is the async version of `list_corpora`."""
     if client is None:
         client = get_default_retriever_async_client()
 
     request = glm.ListCorporaRequest(page_size=page_size)
-    async for corpus in client.list_corpora(request):
+    async for corpus in await client.list_corpora(request):
         corpus = type(corpus).to_dict(corpus)
         yield retriever_types.Corpus(**corpus)

--- a/google/generativeai/retriever.py
+++ b/google/generativeai/retriever.py
@@ -188,11 +188,10 @@ async def delete_corpus_async(name: str, force: bool, client: glm.RetrieverServi
 def list_corpora(
     *,
     page_size: Optional[int] = None,
-    page_token: Optional[str] = None,
     client: glm.RetrieverServiceClient | None = None,
-) -> list[Corpus]:
+) -> Iterable[retriever_types.Corpus]:
     """
-    List `Corpus`.
+    List the Corpuses you own in the service.
 
     Args:
         page_size: Maximum number of `Corpora` to request.
@@ -204,21 +203,22 @@ def list_corpora(
     if client is None:
         client = get_default_retriever_client()
 
-    request = glm.ListCorporaRequest(page_size=page_size, page_token=page_token)
-    response = client.list_corpora(request)
-    return response
+    request = glm.ListCorporaRequest(page_size=page_size)
+    for corpus in client.list_corpora(request):
+        corpus = type(corpus).to_dict(corpus)
+        yield retriever_types.Corpus(**corpus)
 
 
 async def list_corpora_async(
     *,
     page_size: Optional[int] = None,
-    page_token: Optional[str] = None,
     client: glm.RetrieverServiceClient | None = None,
 ) -> list[Corpus]:
     """This is the async version of `list_corpora`."""
     if client is None:
         client = get_default_retriever_async_client()
 
-    request = glm.ListCorporaRequest(page_size=page_size, page_token=page_token)
-    response = await client.list_corpora(request)
-    return response
+    request = glm.ListCorporaRequest(page_size=page_size)
+    async for corpus in client.list_corpora(request):
+        corpus = type(corpus).to_dict(corpus)
+        yield retriever_types.Corpus(**corpus)

--- a/google/generativeai/retriever.py
+++ b/google/generativeai/retriever.py
@@ -205,7 +205,6 @@ async def list_corpora_async(
     client: glm.RetrieverServiceClient | None = None,
 ) -> Iterable[retriever_types.Corpus]:
     """This is the async version of `retriever.list_corpora`."""
-
     if client is None:
         client = get_default_retriever_async_client()
 

--- a/google/generativeai/types/retriever_types.py
+++ b/google/generativeai/types/retriever_types.py
@@ -18,7 +18,7 @@ import re
 import string
 import abc
 import dataclasses
-from typing import Any, Optional, Union, Iterable, Mapping
+from typing import Any, AsyncIterable, Optional, Union, Iterable, Mapping
 
 import google.ai.generativelanguage as glm
 
@@ -464,7 +464,7 @@ class Corpus:
         self,
         page_size: Optional[int] = None,
         client: glm.RetrieverServiceAsyncClient | None = None,
-    ) -> Iterable[Document]:
+    ) -> AsyncIterable[Document]:
         """This is the async version of `Corpus.list_documents`."""
         if client is None:
             client = get_default_retriever_async_client()
@@ -794,7 +794,7 @@ class Document(abc.ABC):
         self,
         page_size: Optional[int] = None,
         client: glm.RetrieverServiceClient | None = None,
-    ) -> Iterable[Chunk]:
+    ) -> AsyncIterable[Chunk]:
         """This is the async version of `Document.list_chunks`."""
         if client is None:
             client = get_default_retriever_async_client()

--- a/google/generativeai/types/retriever_types.py
+++ b/google/generativeai/types/retriever_types.py
@@ -446,7 +446,6 @@ class Corpus:
         Args:
             name: The name of the `Corpus` containing `Document`s.
             page_size: The maximum number of `Document`s to return (per page). The service may return fewer `Document`s.
-            page_token: A page token, received from a previous `ListDocuments` call.
 
         Return:
             Paginated list of `Document`s.
@@ -455,7 +454,8 @@ class Corpus:
             client = get_default_retriever_client()
 
         request = glm.ListDocumentsRequest(
-            parent=self.name, page_size=page_size, page_token=page_token
+            parent=self.name,
+            page_size=page_size,
         )
         for doc in client.list_documents(request):
             yield decode_document(doc)
@@ -470,9 +470,10 @@ class Corpus:
             client = get_default_retriever_async_client()
 
         request = glm.ListDocumentsRequest(
-            parent=self.name, page_size=page_size, page_token=page_token
+            parent=self.name,
+            page_size=page_size,
         )
-        async for doc in client.list_documents(request):
+        async for doc in await client.list_documents(request):
             yield decode_document(doc)
 
     def to_dict(self) -> dict[str, Any]:
@@ -778,7 +779,6 @@ class Document(abc.ABC):
 
         Args:
             page_size: Maximum number of `Chunk`s to request.
-            page_token: A page token, received from a previous ListChunks call.
 
         Return:
             List of chunks in the document.
@@ -787,7 +787,7 @@ class Document(abc.ABC):
             client = get_default_retriever_client()
 
         request = glm.ListChunksRequest(parent=self.name, page_size=page_size)
-        for chunk in client.list_chunk(request):
+        for chunk in client.list_chunks(request):
             yield decode_chunk(chunk)
 
     async def list_chunks_async(
@@ -800,7 +800,7 @@ class Document(abc.ABC):
             client = get_default_retriever_async_client()
 
         request = glm.ListChunksRequest(parent=self.name, page_size=page_size)
-        async for chunk in client.list_chunk(request):
+        async for chunk in await client.list_chunks(request):
             yield decode_chunk(chunk)
 
     def query(

--- a/google/generativeai/types/retriever_types.py
+++ b/google/generativeai/types/retriever_types.py
@@ -215,11 +215,7 @@ class Corpus:
 
         request = glm.CreateDocumentRequest(parent=self.name, document=document)
         response = client.create_document(request)
-        response = type(response).to_dict(response)
-        idecode_time(response, "create_time")
-        idecode_time(response, "update_time")
-        response = Document(**response)
-        return response
+        return decode_document(response)
 
     async def create_document_async(
         self,
@@ -253,11 +249,7 @@ class Corpus:
 
         request = glm.CreateDocumentRequest(parent=self.name, document=document)
         response = await client.create_document(request)
-        response = type(response).to_dict(response)
-        idecode_time(response, "create_time")
-        idecode_time(response, "update_time")
-        response = Document(**response)
-        return response
+        return decode_document(response)
 
     def get_document(
         self,
@@ -278,11 +270,7 @@ class Corpus:
 
         request = glm.GetDocumentRequest(name=name)
         response = client.get_document(request)
-        response = type(response).to_dict(response)
-        idecode_time(response, "create_time")
-        idecode_time(response, "update_time")
-        response = Document(**response)
-        return response
+        return decode_document(response)
 
     async def get_document_async(
         self,
@@ -295,11 +283,7 @@ class Corpus:
 
         request = glm.GetDocumentRequest(name=name)
         response = await client.get_document(request)
-        response = type(response).to_dict(response)
-        idecode_time(response, "create_time")
-        idecode_time(response, "update_time")
-        response = Document(**response)
-        return response
+        return decode_document(response)
 
     def _apply_update(self, path, value):
         parts = path.split(".")
@@ -333,10 +317,7 @@ class Corpus:
             self._apply_update(path, value)
 
         request = glm.UpdateCorpusRequest(corpus=self.to_dict(), update_mask=field_mask)
-        response = client.update_corpus(request)
-        response = type(response).to_dict(response)
-        idecode_time(response, "create_time")
-        idecode_time(response, "update_time")
+        client.update_corpus(request)
         return self
 
     async def update_async(
@@ -357,10 +338,7 @@ class Corpus:
             self._apply_update(path, value)
 
         request = glm.UpdateCorpusRequest(corpus=self.to_dict(), update_mask=field_mask)
-        response = await client.update_corpus(request)
-        response = type(response).to_dict(response)
-        idecode_time(response, "create_time")
-        idecode_time(response, "update_time")
+        await client.update_corpus(request)
         return self
 
     def query(
@@ -441,11 +419,7 @@ class Corpus:
         if client is None:
             client = get_default_retriever_client()
 
-        if force:
-            request = glm.DeleteDocumentRequest(name=name, force=force)
-        else:
-            request = glm.DeleteDocumentRequest(name=name)
-
+        request = glm.DeleteDocumentRequest(name=name, force=bool(force))
         client.delete_document(request)
 
     async def delete_document_async(
@@ -458,19 +432,14 @@ class Corpus:
         if client is None:
             client = get_default_retriever_async_client()
 
-        if force:
-            request = glm.DeleteDocumentRequest(name=name, force=force)
-        else:
-            request = glm.DeleteDocumentRequest(name=name)
-
+        request = glm.DeleteDocumentRequest(name=name, force=bool(force))
         await client.delete_document(request)
 
     def list_documents(
         self,
         page_size: Optional[int] = None,
-        page_token: Optional[str] = None,
         client: glm.RetrieverServiceClient | None = None,
-    ) -> list[Document]:
+    ) -> Iterable[Document]:
         """
         List documents in corpus.
 
@@ -488,15 +457,14 @@ class Corpus:
         request = glm.ListDocumentsRequest(
             parent=self.name, page_size=page_size, page_token=page_token
         )
-        response = client.list_documents(request)
-        return response
+        for doc in client.list_documents(request):
+            yield decode_document(doc)
 
     async def list_documents_async(
         self,
         page_size: Optional[int] = None,
-        page_token: Optional[str] = None,
         client: glm.RetrieverServiceAsyncClient | None = None,
-    ) -> list[Document]:
+    ) -> Iterable[Document]:
         """This is the async version of `Corpus.list_documents`."""
         if client is None:
             client = get_default_retriever_async_client()
@@ -504,12 +472,19 @@ class Corpus:
         request = glm.ListDocumentsRequest(
             parent=self.name, page_size=page_size, page_token=page_token
         )
-        response = await client.list_documents(request)
-        return response
+        async for doc in client.list_documents(request):
+            yield decode_document(doc)
 
     def to_dict(self) -> dict[str, Any]:
         result = {"name": self.name, "display_name": self.display_name}
         return result
+
+
+def decode_document(document):
+    document = type(document).to_dict(document)
+    idecode_time(document, "create_time")
+    idecode_time(document, "update_time")
+    return Document(**document)
 
 
 @string_utils.prettyprint
@@ -573,11 +548,7 @@ class Document(abc.ABC):
 
         request = glm.CreateChunkRequest(parent=self.name, chunk=chunk)
         response = client.create_chunk(request)
-        response = type(response).to_dict(response)
-        idecode_time(response, "create_time")
-        idecode_time(response, "update_time")
-        response = Chunk(**response)
-        return response
+        return decode_chunk(response)
 
     async def create_chunk_async(
         self,
@@ -615,11 +586,7 @@ class Document(abc.ABC):
 
         request = glm.CreateChunkRequest(parent=self.name, chunk=chunk)
         response = await client.create_chunk(request)
-        response = type(response).to_dict(response)
-        idecode_time(response, "create_time")
-        idecode_time(response, "update_time")
-        response = Chunk(**response)
-        return response
+        return decode_chunk(response)
 
     def batch_create_chunks(
         self,
@@ -696,8 +663,7 @@ class Document(abc.ABC):
 
         request = glm.BatchCreateChunksRequest(parent=self.name, requests=_requests)
         response = client.batch_create_chunks(request)
-        response = type(response).to_dict(response)
-        return response
+        return [decode_chunk(chunk) for chunk in response.chunks]
 
     async def batch_create_chunks_async(
         self,
@@ -766,8 +732,7 @@ class Document(abc.ABC):
 
         request = glm.BatchCreateChunksRequest(parent=self.name, requests=_requests)
         response = await client.batch_create_chunks(request)
-        response = type(response).to_dict(response)
-        return response
+        return [decode_chunk(chunk) for chunk in response.chunks]
 
     def get_chunk(
         self,
@@ -788,11 +753,7 @@ class Document(abc.ABC):
 
         request = glm.GetChunkRequest(name=name)
         response = client.get_chunk(request)
-        response = type(response).to_dict(response)
-        idecode_time(response, "create_time")
-        idecode_time(response, "update_time")
-        response = Chunk(**response)
-        return response
+        return decode_chunk(response)
 
     async def get_chunk_async(
         self,
@@ -805,18 +766,13 @@ class Document(abc.ABC):
 
         request = glm.GetChunkRequest(name=name)
         response = await client.get_chunk(request)
-        response = type(response).to_dict(response)
-        idecode_time(response, "create_time")
-        idecode_time(response, "update_time")
-        response = Chunk(**response)
-        return response
+        return decode_chunk(response)
 
     def list_chunks(
         self,
         page_size: Optional[int] = None,
-        page_token: Optional[str] = None,
         client: glm.RetrieverServiceClient | None = None,
-    ):
+    ) -> Iterable[Chunk]:
         """
         List chunks of a document.
 
@@ -830,27 +786,22 @@ class Document(abc.ABC):
         if client is None:
             client = get_default_retriever_client()
 
-        request = glm.ListChunksRequest(
-            parent=self.name, page_size=page_size, page_token=page_token
-        )
-        response = client.list_chunks(request)
-        return response
+        request = glm.ListChunksRequest(parent=self.name, page_size=page_size)
+        for chunk in client.list_chunk(request):
+            yield decode_chunk(chunk)
 
     async def list_chunks_async(
         self,
         page_size: Optional[int] = None,
-        page_token: Optional[str] = None,
         client: glm.RetrieverServiceClient | None = None,
-    ):
+    ) -> Iterable[Chunk]:
         """This is the async version of `Document.list_chunks`."""
         if client is None:
             client = get_default_retriever_async_client()
 
-        request = glm.ListChunksRequest(
-            parent=self.name, page_size=page_size, page_token=page_token
-        )
-        response = await client.list_chunks(request)
-        return response
+        request = glm.ListChunksRequest(parent=self.name, page_size=page_size)
+        async for chunk in client.list_chunk(request):
+            yield decode_chunk(chunk)
 
     def query(
         self,
@@ -946,10 +897,6 @@ class Document(abc.ABC):
 
         request = glm.UpdateDocumentRequest(document=self.to_dict(), update_mask=field_mask)
         response = client.update_document(request)
-        response = type(response).to_dict(response)
-        idecode_time(response, "create_time")
-        idecode_time(response, "update_time")
-        return self
 
     async def update_async(
         self,
@@ -969,10 +916,6 @@ class Document(abc.ABC):
 
         request = glm.UpdateDocumentRequest(document=self.to_dict(), update_mask=field_mask)
         response = await client.update_document(request)
-        response = type(response).to_dict(response)
-        idecode_time(response, "create_time")
-        idecode_time(response, "update_time")
-        return self
 
     def batch_update_chunks(
         self,
@@ -1177,6 +1120,13 @@ class Document(abc.ABC):
         return result
 
 
+def decode_chunk(chunk: glm.Chunk) -> Chunk:
+    chunk = type(chunk).to_dict(chunk)
+    idecode_time(chunk, "create_time")
+    idecode_time(chunk, "update_time")
+    return Chunk(**chunk)
+
+
 @string_utils.prettyprint
 @dataclasses.dataclass(init=False)
 class Chunk(abc.ABC):
@@ -1237,13 +1187,7 @@ class Chunk(abc.ABC):
         for path, value in updates.items():
             self._apply_update(path, value)
         request = glm.UpdateChunkRequest(chunk=self.to_dict(), update_mask=field_mask)
-        response = client.update_chunk(request)
-        response = type(response).to_dict(response)
-
-        idecode_time(response, "create_time")
-        idecode_time(response, "update_time")
-
-        return self
+        client.update_chunk(request)
 
     async def update_async(
         self,
@@ -1261,13 +1205,7 @@ class Chunk(abc.ABC):
         for path, value in updates.items():
             self._apply_update(path, value)
         request = glm.UpdateChunkRequest(chunk=self.to_dict(), update_mask=field_mask)
-        response = await client.update_chunk(request)
-        response = type(response).to_dict(response)
-
-        idecode_time(response, "create_time")
-        idecode_time(response, "update_time")
-
-        return self
+        await client.update_chunk(request)
 
     def to_dict(self) -> dict[str, Any]:
         result = {

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -278,8 +278,7 @@ class UnitTests(parameterized.TestCase):
         self.assertEqual("demo_corpus_1", demo_corpus.display_name)
 
     def test_list_corpora(self):
-        x = retriever.list_corpora(page_size=1)
-        self.assertIsInstance(x, list)
+        x = list(retriever.list_corpora(page_size=1))
         self.assertEqual(len(x), 2)
 
     def test_query_corpus(self):
@@ -361,7 +360,7 @@ class UnitTests(parameterized.TestCase):
         demo_corpus = retriever.create_corpus(display_name="demo_corpus")
         demo_document = demo_corpus.create_document(display_name="demo_doc")
         demo_doc2 = demo_corpus.create_document(display_name="demo_doc_2")
-        self.assertLen(demo_corpus.list_documents(), 2)
+        self.assertLen(list(demo_corpus.list_documents()), 2)
 
     def test_query_document(self):
         demo_corpus = retriever.create_corpus(display_name="demo_corpus")
@@ -457,12 +456,10 @@ class UnitTests(parameterized.TestCase):
     def test_batch_create_chunks(self, chunks):
         demo_corpus = retriever.create_corpus(display_name="demo_corpus")
         demo_document = demo_corpus.create_document(display_name="demo_doc")
-        creation_req = demo_document.batch_create_chunks(chunks=chunks)
+        chunks = demo_document.batch_create_chunks(chunks=chunks)
         self.assertIsInstance(self.observed_requests[-1], glm.BatchCreateChunksRequest)
-        self.assertEqual("This is a demo chunk.", creation_req["chunks"][0]["data"]["string_value"])
-        self.assertEqual(
-            "This is another demo chunk.", creation_req["chunks"][1]["data"]["string_value"]
-        )
+        self.assertEqual("This is a demo chunk.", chunks[0].data.string_value)
+        self.assertEqual("This is another demo chunk.", chunks[1].data.string_value)
 
     def test_get_chunk(self):
         demo_corpus = retriever.create_corpus(display_name="demo_corpus")
@@ -485,7 +482,8 @@ class UnitTests(parameterized.TestCase):
             name="corpora/demo_corpus/documents/demo_doc/chunks/demo_chunk_1",
             data="This is another demo chunk.",
         )
-        list_req = demo_document.list_chunks()
+
+        list_req = list(demo_document.list_chunks())
         self.assertIsInstance(self.observed_requests[-1], glm.ListChunksRequest)
         self.assertLen(list_req, 2)
 
@@ -496,12 +494,10 @@ class UnitTests(parameterized.TestCase):
             name="corpora/demo_corpus/documents/demo_doc/chunks/demo_chunk",
             data="This is a demo chunk.",
         )
-        update_request = x.update(
-            updates={"data": {"string_value": "This is an updated demo chunk."}}
-        )
+        x.update(updates={"data": {"string_value": "This is an updated demo chunk."}})
         self.assertEqual(
             retriever_service.ChunkData("This is an updated demo chunk."),
-            update_request.data,
+            x.data,
         )
 
     @parameterized.named_parameters(


### PR DESCRIPTION
1. The `list` methods should return iterables of Corpus/Document/Chunk objects, and not expose the page-token.
2. Add `decode_document` and `decode_chunk` for use Everywhere the API returns a corpus or document.