### PR TITLE
Implement __repr__ for GenerateContentResponse and ChatSession

### DIFF
--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -497,7 +497,11 @@ class ChatSession:
         def content_repr(x):
             return f"glm.Content({_dict_repr.repr(type(x).to_dict(x))})"
 
-        history = list(self._history)
+        try:
+            history = list(self.history)
+        except (generation_types.BrokenResponseError, generation_types.IncompleteIterationError):
+            history = list(self._history)
+
         if self._last_sent is not None:
             history.append(self._last_sent)
         history = [content_repr(x) for x in history]
@@ -506,11 +510,6 @@ class ChatSession:
         if last_received is not None:
             if last_received._error is not None:
                 history.append("<STREAMING ERROR>")
-            elif last_received._done:
-                content = self._last_received.candidates[0].content
-                if not content.role:
-                    content.role = self._MODEL_ROLE
-                history.append(content_repr(content))
             else:
                 history.append("<STREAMING IN PROGRESS>")
 

--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 import dataclasses
 import textwrap
 from typing import Union
+import reprlib
 
 # pylint: disable=bad-continuation, line-too-long
 
@@ -490,10 +491,11 @@ class ChatSession:
         self._last_received = None
 
     def __repr__(self) -> str:
+        _dict_repr = reprlib.Repr()
         _model = str(self.model).replace("\n", "\n" + " " * 4)
         _history = (
             ",\n    "
-            + f"history=[{', '.join(['glm.Content('+str( type(x).to_dict(x) )+')' for x in self._history ])}]\n)"
+            + f"history=[{', '.join(['glm.Content('+_dict_repr.repr(type(x).to_dict(x))+')' for x in self._history ])}]\n)"
         )
 
         return (

--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -89,11 +89,11 @@ class GenerativeModel:
 
     def __str__(self):
         return textwrap.dedent(
-            f""" \
+            f"""\
             genai.GenerativeModel(
-               model_name='{self.model_name}',
-               generation_config={self._generation_config}.
-               safety_settings={self._safety_settings}
+                model_name='{self.model_name}',
+                generation_config={self._generation_config}.
+                safety_settings={self._safety_settings}
             )"""
         )
 
@@ -488,3 +488,20 @@ class ChatSession:
         self._history = content_types.to_contents(history)
         self._last_self = None
         self._last_received = None
+
+    def __repr__(self) -> str:
+        _model = str(self.model).replace("\n", "\n" + " " * 4)
+        _history = (
+            ",\n    "
+            + f"history=[{', '.join(['glm.Content('+str( type(x).to_dict(x) )+')' for x in self._history ])}]\n)"
+        )
+
+        return (
+            textwrap.dedent(
+                f"""\
+                ChatSession(
+                    model="""
+            )
+            + _model
+            + _history
+        )

--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -474,7 +474,7 @@ class ChatSession:
             ) from last._error
 
         sent = self._last_sent
-        received = self._last_received.candidates[0].content
+        received = last.candidates[0].content
         if not received.role:
             received.role = self._MODEL_ROLE
         self._history.extend([sent, received])
@@ -487,16 +487,32 @@ class ChatSession:
     @history.setter
     def history(self, history):
         self._history = content_types.to_contents(history)
-        self._last_self = None
+        self._last_sent = None
         self._last_received = None
 
     def __repr__(self) -> str:
         _dict_repr = reprlib.Repr()
         _model = str(self.model).replace("\n", "\n" + " " * 4)
-        _history = (
-            ",\n    "
-            + f"history=[{', '.join(['glm.Content('+_dict_repr.repr(type(x).to_dict(x))+')' for x in self.history ])}]\n)"
-        )
+
+        def content_repr(x):
+            return f"glm.Content({_dict_repr.repr(type(x).to_dict(x))})"
+
+        history = list(self._history)
+        if self._last_sent is not None:
+            history.append(self._last_sent)
+        history = [content_repr(x) for x in history]
+
+        last_received = self._last_received
+        if last_received is not None:
+            if last_received._done:
+                content = self._last_received.candidates[0].content
+                if not content.role:
+                    content.role = self._MODEL_ROLE
+                history.append(content_repr(content))
+            else:
+                history.append("<STREAMING IN PROGRESS>")
+
+        _history = ",\n    " + f"history=[{', '.join(history)}]\n)"
 
         return (
             textwrap.dedent(

--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -495,7 +495,7 @@ class ChatSession:
         _model = str(self.model).replace("\n", "\n" + " " * 4)
         _history = (
             ",\n    "
-            + f"history=[{', '.join(['glm.Content('+_dict_repr.repr(type(x).to_dict(x))+')' for x in self._history ])}]\n)"
+            + f"history=[{', '.join(['glm.Content('+_dict_repr.repr(type(x).to_dict(x))+')' for x in self.history ])}]\n)"
         )
 
         return (

--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -504,7 +504,9 @@ class ChatSession:
 
         last_received = self._last_received
         if last_received is not None:
-            if last_received._done:
+            if last_received._error is not None:
+                history.append("<STREAMING ERROR>")
+            elif last_received._done:
                 content = self._last_received.candidates[0].content
                 if not content.role:
                     content.role = self._MODEL_ROLE

--- a/google/generativeai/types/generation_types.py
+++ b/google/generativeai/types/generation_types.py
@@ -466,7 +466,7 @@ class GenerateContentResponse(BaseGenerateContentResponse):
         _result = f"glm.GenerateContentResponse({type(self._result).to_dict(self._result)})"
 
         if self._error:
-            _error = f",\nerror={self._error.__class__.__name__}, {self._error}"
+            _error = f",\nerror=<{self._error.__class__.__name__}> {self._error}"
         else:
             _error = ""
 

--- a/google/generativeai/types/generation_types.py
+++ b/google/generativeai/types/generation_types.py
@@ -274,7 +274,7 @@ class BaseGenerateContentResponse:
             | AsyncIterable[glm.GenerateContentResponse]
         ),
         result: glm.GenerateContentResponse,
-        chunks: Iterable[glm.GenerateContentResponse] | None,
+        chunks: Iterable[glm.GenerateContentResponse] | None = None,
     ):
         self._done = done
         self._iterator = iterator
@@ -498,7 +498,6 @@ class AsyncGenerateContentResponse(BaseGenerateContentResponse):
             done=False,
             iterator=iterator,
             result=response,
-            chunks=[response],
         )
 
     @classmethod
@@ -507,7 +506,6 @@ class AsyncGenerateContentResponse(BaseGenerateContentResponse):
             done=True,
             iterator=None,
             result=response,
-            chunks=[response],
         )
 
     async def __aiter__(self):

--- a/google/generativeai/types/generation_types.py
+++ b/google/generativeai/types/generation_types.py
@@ -347,6 +347,34 @@ class BaseGenerateContentResponse:
     def prompt_feedback(self):
         return self._result.prompt_feedback
 
+    def __str__(self) -> str:
+        if self._done:
+            _iterator = "None"
+        else:
+            _iterator = f"<{self._iterator.__class__.__name__}>"
+
+        _result = f"glm.GenerateContentResponse({type(self._result).to_dict(self._result)})"
+
+        if self._error:
+            _error = f",\nerror=<{self._error.__class__.__name__}> {self._error}"
+        else:
+            _error = ""
+
+        return (
+            textwrap.dedent(
+                f"""\
+                response:
+                {type(self).__name__}(
+                    done={self._done},
+                    iterator={_iterator},
+                    result={_result},
+                )"""
+            )
+            + _error
+        )
+
+    __repr__ = __str__
+
 
 @contextlib.contextmanager
 def rewrite_stream_error():
@@ -455,45 +483,6 @@ class GenerateContentResponse(BaseGenerateContentResponse):
 
         for _ in self:
             pass
-
-    def __repr__(self) -> str:
-        if self._done:
-            _iterator = "None"
-        else:
-            _iterator = f"<{self._iterator.__class__.__name__}>"
-
-        _chunks = self._iterable_to_string(self._chunks)
-        _result = f"glm.GenerateContentResponse({type(self._result).to_dict(self._result)})"
-
-        if self._error:
-            _error = f",\nerror=<{self._error.__class__.__name__}> {self._error}"
-        else:
-            _error = ""
-
-        return (
-            textwrap.dedent(
-                f"""\
-                response:
-                GenerateContentResponse(
-                    done={self._done},
-                    iterator={_iterator},
-                    result={_result},
-                    chunks={_chunks}
-                )"""
-            )
-            + _error
-        )
-
-    def _iterable_to_string(self, iterable: List[glm.GenerateContentResponse]) -> str:
-        if iterable is None:
-            return "[]"
-
-        repr_string = []
-        for cr in iterable:
-            repr_string.append(f"glm.GenerateContentResponse({type(cr).to_dict(cr)})")
-
-        repr_string = f"iter([{', '.join(repr_string)}])"
-        return repr_string
 
 
 @string_utils.set_doc(ASYNC_GENERATE_CONTENT_RESPONSE_DOC)

--- a/google/generativeai/types/generation_types.py
+++ b/google/generativeai/types/generation_types.py
@@ -467,7 +467,7 @@ class GenerateContentResponse(BaseGenerateContentResponse):
         result = f"glm.GenerateContentResponse({type(self._result).to_dict(self._result)})"
 
         return textwrap.dedent(
-            f"""
+            f"""\
             GenerateContentResponse(
                 done={self._done},
                 iterator={iterator_repr},

--- a/google/generativeai/types/generation_types.py
+++ b/google/generativeai/types/generation_types.py
@@ -274,12 +274,15 @@ class BaseGenerateContentResponse:
             | AsyncIterable[glm.GenerateContentResponse]
         ),
         result: glm.GenerateContentResponse,
-        chunks: Iterable[glm.GenerateContentResponse],
+        chunks: Iterable[glm.GenerateContentResponse] | None,
     ):
         self._done = done
         self._iterator = iterator
         self._result = result
-        self._chunks = list(chunks)
+        if chunks is None:
+            self._chunks = [result]
+        else:
+            self._chunks = list(chunks)
         if result.prompt_feedback.block_reason:
             self._error = BlockedPromptException(result)
         else:
@@ -428,7 +431,6 @@ class GenerateContentResponse(BaseGenerateContentResponse):
             done=False,
             iterator=iterator,
             result=response,
-            chunks=[response],
         )
 
     @classmethod
@@ -437,7 +439,6 @@ class GenerateContentResponse(BaseGenerateContentResponse):
             done=True,
             iterator=None,
             result=response,
-            chunks=[response],
         )
 
     def __iter__(self):

--- a/google/generativeai/types/generation_types.py
+++ b/google/generativeai/types/generation_types.py
@@ -457,18 +457,31 @@ class GenerateContentResponse(BaseGenerateContentResponse):
             pass
 
     def __repr__(self) -> str:
-        iterator_repr = self._iterable_to_string(self._iterator)
-        chunks_repr = self._iterable_to_string(self._chunks)
+        if self._done:
+            iterator = "None"
+        else:
+            iterator = f"<{self._iterator.__class__.__name__}>"
+
+        chunks = self._iterable_to_string(self._chunks)
         result = f"glm.GenerateContentResponse({type(self._result).to_dict(self._result)})"
 
-        return textwrap.dedent(
-            f"""\
-            GenerateContentResponse(
-                done={self._done},
-                iterator={iterator_repr},
-                result={result},
-                chunks={chunks_repr},
-            )"""
+        if self._error:
+            error = f",\nerror={self._error.__class__.__name__}, {self._error}"
+        else:
+            error = ""
+
+        return (
+            textwrap.dedent(
+                f"""\
+                response:
+                GenerateContentResponse(
+                    done={self._done},
+                    iterator={iterator},
+                    result={result},
+                    chunks={chunks}
+                )"""
+            )
+            + error
         )
 
     def _iterable_to_string(self, iterable: List[glm.GenerateContentResponse]) -> str:

--- a/google/generativeai/types/generation_types.py
+++ b/google/generativeai/types/generation_types.py
@@ -276,7 +276,6 @@ class BaseGenerateContentResponse:
         result: glm.GenerateContentResponse,
         chunks: Iterable[glm.GenerateContentResponse],
     ):
-        iterator, chunks = self._stash_iterators_for_repr(iterator, chunks)
         self._done = done
         self._iterator = iterator
         self._result = result
@@ -285,26 +284,6 @@ class BaseGenerateContentResponse:
             self._error = BlockedPromptException(result)
         else:
             self._error = None
-
-    def _stash_iterators_for_repr(
-        self,
-        iterator: (
-            None
-            | Iterable[glm.GenerateContentResponse]
-            | AsyncIterable[glm.GenerateContentResponse]
-        ),
-        chunks: Iterable[glm.GenerateContentResponse],
-    ) -> Tuple[
-        (None | Iterable[glm.GenerateContentResponse] | AsyncIterable[glm.GenerateContentResponse]),
-        Iterable[glm.GenerateContentResponse],
-    ]:
-        self._iterator_as_list = None
-        if iterator is not None:
-            iterator, iterator_copy = itertools.tee(iterator)
-            self._iterator_as_list = list(iterator_copy)
-        chunks, chunks_copy = itertools.tee(chunks)
-        self._chunks_as_list = list(chunks_copy)
-        return iterator, chunks
 
     @property
     def candidates(self):
@@ -478,8 +457,8 @@ class GenerateContentResponse(BaseGenerateContentResponse):
             pass
 
     def __repr__(self) -> str:
-        iterator_repr = self._iterable_to_string(self._iterator_as_list)
-        chunks_repr = self._iterable_to_string(self._chunks_as_list)
+        iterator_repr = self._iterable_to_string(self._iterator)
+        chunks_repr = self._iterable_to_string(self._chunks)
         result = f"glm.GenerateContentResponse({type(self._result).to_dict(self._result)})"
 
         return textwrap.dedent(

--- a/google/generativeai/types/generation_types.py
+++ b/google/generativeai/types/generation_types.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable, AsyncIterable
 import dataclasses
 import itertools
 import textwrap
-from typing import TypedDict, Union
+from typing import List, TypedDict, Union
 
 import google.protobuf.json_format
 import google.api_core.exceptions
@@ -278,8 +278,13 @@ class BaseGenerateContentResponse:
     ):
         self._done = done
         self._iterator = iterator
+        if self._iterator is not None:
+            self._iterator_as_list = list(self._iterator)
+        else:
+            self._iterator_as_list = None
         self._result = result
         self._chunks = list(chunks)
+        self._chunks_as_list = list(chunks)
         if result.prompt_feedback.block_reason:
             self._error = BlockedPromptException(result)
         else:
@@ -455,6 +460,32 @@ class GenerateContentResponse(BaseGenerateContentResponse):
 
         for _ in self:
             pass
+
+    def __repr__(self) -> str:
+        iterator_repr = self._iterable_to_string(self._iterator_as_list)
+        chunks_repr = self._iterable_to_string(self._chunks_as_list)
+        result = f"glm.GenerateContentResponse({type(self._result).to_dict(self._result)})"
+
+        return textwrap.dedent(
+            f"""
+            GenerateContentResponse(
+                done={self._done},
+                iterator={iterator_repr},
+                result={result},
+                chunks={chunks_repr},
+            )"""
+        )
+
+    def _iterable_to_string(self, iterable: List[glm.GenerateContentResponse]):
+        if iterable is None:
+            return "[]"
+
+        repr_string = []
+        for cr in iterable:
+            repr_string.append(f"glm.GenerateContentResponse({type(cr).to_dict(cr)})")
+
+        repr_string = f"iter([{', '.join(repr_string)}])"
+        return repr_string
 
 
 @string_utils.set_doc(ASYNC_GENERATE_CONTENT_RESPONSE_DOC)

--- a/google/generativeai/types/generation_types.py
+++ b/google/generativeai/types/generation_types.py
@@ -458,17 +458,17 @@ class GenerateContentResponse(BaseGenerateContentResponse):
 
     def __repr__(self) -> str:
         if self._done:
-            iterator = "None"
+            _iterator = "None"
         else:
-            iterator = f"<{self._iterator.__class__.__name__}>"
+            _iterator = f"<{self._iterator.__class__.__name__}>"
 
-        chunks = self._iterable_to_string(self._chunks)
-        result = f"glm.GenerateContentResponse({type(self._result).to_dict(self._result)})"
+        _chunks = self._iterable_to_string(self._chunks)
+        _result = f"glm.GenerateContentResponse({type(self._result).to_dict(self._result)})"
 
         if self._error:
-            error = f",\nerror={self._error.__class__.__name__}, {self._error}"
+            _error = f",\nerror={self._error.__class__.__name__}, {self._error}"
         else:
-            error = ""
+            _error = ""
 
         return (
             textwrap.dedent(
@@ -476,12 +476,12 @@ class GenerateContentResponse(BaseGenerateContentResponse):
                 response:
                 GenerateContentResponse(
                     done={self._done},
-                    iterator={iterator},
-                    result={result},
-                    chunks={chunks}
+                    iterator={_iterator},
+                    result={_result},
+                    chunks={_chunks}
                 )"""
             )
-            + error
+            + _error
         )
 
     def _iterable_to_string(self, iterable: List[glm.GenerateContentResponse]) -> str:

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -498,7 +498,7 @@ class UnitTests(parameterized.TestCase):
 
         result = repr(response)
         expected = textwrap.dedent(
-            """
+            """\
             GenerateContentResponse(
                 done=True,
                 iterator=[],
@@ -517,7 +517,7 @@ class UnitTests(parameterized.TestCase):
 
         result = repr(response)
         expected = textwrap.dedent(
-            """
+            """\
             GenerateContentResponse(
                 done=False,
                 iterator=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'b'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'c'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'd'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})]),

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -504,7 +504,6 @@ class UnitTests(parameterized.TestCase):
                 done=True,
                 iterator=None,
                 result=glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'Hello world!'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}),
-                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'Hello world!'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})])
             )"""
         )
         self.assertEqual(expected, result)
@@ -524,7 +523,6 @@ class UnitTests(parameterized.TestCase):
                 done=False,
                 iterator=<list_iterator>,
                 result=glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'a'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}),
-                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'a'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})])
             )"""
         )
         self.assertEqual(expected, result)

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,5 +1,6 @@
 import inspect
 import string
+import textwrap
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -488,6 +489,43 @@ class UnitTests(parameterized.TestCase):
             self.assertEqual(
                 type(raw_response).to_dict(raw_response), type(chunk._result).to_dict(chunk._result)
             )
+
+    def test_repr_for_generate_content_response_from_response(self):
+        raw_response = glm.GenerateContentResponse(
+            {"candidates": [{"content": {"parts": [{"text": "Hello world!"}]}}]}
+        )
+        response = generation_types.GenerateContentResponse.from_response(raw_response)
+
+        result = repr(response)
+        expected = textwrap.dedent(
+            """
+            GenerateContentResponse(
+                done=True,
+                iterator=[],
+                result=glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'Hello world!'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}),
+                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'Hello world!'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})]),
+            )"""
+        )
+        self.assertEqual(expected, result)
+
+    def test_repr_for_generate_content_response_from_iterator(self):
+        chunks = [
+            glm.GenerateContentResponse({"candidates": [{"content": {"parts": [{"text": a}]}}]})
+            for a in "abcd"
+        ]
+        response = generation_types.GenerateContentResponse.from_iterator(iter(chunks))
+
+        result = repr(response)
+        expected = textwrap.dedent(
+            """
+            GenerateContentResponse(
+                done=False,
+                iterator=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'b'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'c'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'd'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})]),
+                result=glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'a'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}),
+                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'a'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})]),
+            )"""
+        )
+        self.assertEqual(expected, result)
 
 
 if __name__ == "__main__":

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -499,11 +499,12 @@ class UnitTests(parameterized.TestCase):
         result = repr(response)
         expected = textwrap.dedent(
             """\
+            response:
             GenerateContentResponse(
                 done=True,
-                iterator=[],
+                iterator=None,
                 result=glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'Hello world!'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}),
-                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'Hello world!'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})]),
+                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'Hello world!'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})])
             )"""
         )
         self.assertEqual(expected, result)
@@ -518,11 +519,12 @@ class UnitTests(parameterized.TestCase):
         result = repr(response)
         expected = textwrap.dedent(
             """\
+            response:
             GenerateContentResponse(
                 done=False,
-                iterator=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'b'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'c'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'd'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})]),
+                iterator=<list_iterator>,
                 result=glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'a'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}),
-                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'a'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})]),
+                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'a'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})])
             )"""
         )
         self.assertEqual(expected, result)

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -674,7 +674,6 @@ class CUJTests(parameterized.TestCase):
                 done=True,
                 iterator=None,
                 result=glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'world!'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}),
-                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'world!'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})])
             )"""
         )
         self.assertEqual(expected, result)
@@ -695,7 +694,6 @@ class CUJTests(parameterized.TestCase):
                 done=False,
                 iterator=<generator>,
                 result=glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'first'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}),
-                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'first'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})])
             )"""
         )
         self.assertEqual(expected1, result1)
@@ -709,7 +707,6 @@ class CUJTests(parameterized.TestCase):
                 done=False,
                 iterator=<generator>,
                 result=glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'first second'}], 'role': ''}, 'index': 0, 'citation_metadata': {'citation_sources': []}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}], 'prompt_feedback': {'block_reason': 0, 'safety_ratings': []}}),
-                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'first'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': ' second'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})])
             )"""
         )
         self.assertEqual(expected2, result2)
@@ -723,7 +720,6 @@ class CUJTests(parameterized.TestCase):
                 done=False,
                 iterator=<generator>,
                 result=glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'first second third'}], 'role': ''}, 'index': 0, 'citation_metadata': {'citation_sources': []}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}], 'prompt_feedback': {'block_reason': 0, 'safety_ratings': []}}),
-                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'first'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': ' second'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': ' third'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})])
             )"""
         )
         self.assertEqual(expected3, result3)
@@ -750,7 +746,6 @@ class CUJTests(parameterized.TestCase):
                 done=False,
                 iterator=<generator>,
                 result=glm.GenerateContentResponse({'prompt_feedback': {'block_reason': 1, 'safety_ratings': []}, 'candidates': []}),
-                chunks=iter([glm.GenerateContentResponse({'prompt_feedback': {'block_reason': 1, 'safety_ratings': []}, 'candidates': []})])
             ),
             error=<BlockedPromptException> prompt_feedback {
               block_reason: SAFETY
@@ -797,7 +792,6 @@ class CUJTests(parameterized.TestCase):
                 done=True,
                 iterator=None,
                 result=glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': '123'}], 'role': ''}, 'index': 0, 'citation_metadata': {'citation_sources': []}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}], 'prompt_feedback': {'block_reason': 0, 'safety_ratings': []}}),
-                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': '1'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': '2'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': '3'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})])
             ),
             error=<ValueError> """
         )
@@ -841,7 +835,6 @@ class CUJTests(parameterized.TestCase):
                 done=True,
                 iterator=None,
                 result=glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'abc'}], 'role': ''}, 'finish_reason': 3, 'index': 0, 'citation_metadata': {'citation_sources': []}, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}], 'prompt_feedback': {'block_reason': 0, 'safety_ratings': []}}),
-                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'a'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'b'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'c'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'finish_reason': 3, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})])
             ),
             error=<StopCandidateException> index: 0
             content {

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -856,6 +856,40 @@ class CUJTests(parameterized.TestCase):
         )
         self.assertEqual(expected, result)
 
+    def test_repr_for_multi_turn_chat(self):
+        # Multi turn chat
+        model = generative_models.GenerativeModel("gemini-pro")
+        chat = model.start_chat()
+
+        self.responses["generate_content"] = [
+            simple_response("first"),
+            simple_response("second"),
+            simple_response("third"),
+        ]
+
+        msg1 = "I really like fantasy books."
+        response = chat.send_message(msg1)
+
+        msg2 = "I also like this image."
+        response = chat.send_message([msg2, PIL.Image.open(TEST_IMAGE_PATH)])
+
+        msg3 = "What things do I like?."
+        response = chat.send_message(msg3)
+
+        result = repr(chat)
+        expected = textwrap.dedent(
+            """\
+            ChatSession(
+                model=genai.GenerativeModel(
+                    model_name='models/gemini-pro',
+                    generation_config={}.
+                    safety_settings={}
+                ),
+                history=[glm.Content({'parts': [{'text': 'I really like fantasy books.'}], 'role': 'user'}), glm.Content({'parts': [{'text': 'first'}], 'role': 'model'}), glm.Content({'parts': [{'text': 'I also like this image.'}, {'inline_data': {'data': 'iVBORw0KGgoA...AAElFTkSuQmCC', 'mime_type': 'image/png'}}], 'role': 'user'}), glm.Content({'parts': [{'text': 'second'}], 'role': 'model'}), glm.Content({'parts': [{'text': 'What things do I like?.'}], 'role': 'user'}), glm.Content({'parts': [{'text': 'third'}], 'role': 'model'})]
+            )"""
+        )
+        self.assertEqual(expected, result)
+
 
 if __name__ == "__main__":
     absltest.main()

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -728,6 +728,36 @@ class CUJTests(parameterized.TestCase):
         )
         self.assertEqual(expected3, result3)
 
+    def test_repr_error_info_for_stream_prompt_feedback_blocked(self):
+        chunks = [
+            glm.GenerateContentResponse(
+                {
+                    "prompt_feedback": {"block_reason": "SAFETY"},
+                }
+            )
+        ]
+        self.responses["stream_generate_content"] = [(chunk for chunk in chunks)]
+
+        model = generative_models.GenerativeModel("gemini-pro")
+        response = model.generate_content("Bad stuff!", stream=True)
+
+        result = repr(response)
+        expected = textwrap.dedent(
+            """\
+            response:
+            GenerateContentResponse(
+                done=False,
+                iterator=<generator>,
+                result=glm.GenerateContentResponse({'prompt_feedback': {'block_reason': 1, 'safety_ratings': []}, 'candidates': []}),
+                chunks=iter([glm.GenerateContentResponse({'prompt_feedback': {'block_reason': 1, 'safety_ratings': []}, 'candidates': []})])
+            ),
+            error=<BlockedPromptException> prompt_feedback {
+              block_reason: SAFETY
+            }
+            """
+        )
+        self.assertEqual(expected, result)
+
 
 if __name__ == "__main__":
     absltest.main()

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -2,6 +2,7 @@ import collections
 from collections.abc import Iterable
 import copy
 import pathlib
+import textwrap
 import unittest.mock
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -659,6 +660,24 @@ class CUJTests(parameterized.TestCase):
 
         asource = re.sub(" *?# type: ignore", "", asource)
         self.assertEqual(source, asource)
+
+    def test_repr_for_unary_non_streamed_response(self):
+        model = generative_models.GenerativeModel(model_name="gemini-pro")
+        self.responses["generate_content"].append(simple_response("world!"))
+        response = model.generate_content("Hello")
+
+        result = repr(response)
+        expected = textwrap.dedent(
+            """\
+            response:
+            GenerateContentResponse(
+                done=True,
+                iterator=None,
+                result=glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'world!'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}),
+                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'world!'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})])
+            )"""
+        )
+        self.assertEqual(expected, result)
 
 
 if __name__ == "__main__":

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -729,6 +729,7 @@ class CUJTests(parameterized.TestCase):
         self.assertEqual(expected3, result3)
 
     def test_repr_error_info_for_stream_prompt_feedback_blocked(self):
+        # response._error => BlockedPromptException
         chunks = [
             glm.GenerateContentResponse(
                 {
@@ -759,6 +760,7 @@ class CUJTests(parameterized.TestCase):
         self.assertEqual(expected, result)
 
     def test_repr_error_info_for_chat_error_in_stream(self):
+        # response._error => ValueError
         def throw():
             for c in "123":
                 yield simple_response(c)
@@ -802,6 +804,7 @@ class CUJTests(parameterized.TestCase):
         self.assertEqual(expected, result)
 
     def test_repr_error_info_for_chat_streaming_unexpected_stop(self):
+        # response._error => StopCandidateException
         self.responses["stream_generate_content"] = [
             iter(
                 [

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -679,6 +679,55 @@ class CUJTests(parameterized.TestCase):
         )
         self.assertEqual(expected, result)
 
+    def test_repr_for_streaming_start_to_finish(self):
+        chunks = ["first", " second", " third"]
+        self.responses["stream_generate_content"] = [(simple_response(text) for text in chunks)]
+
+        model = generative_models.GenerativeModel("gemini-pro")
+        response = model.generate_content("Hello", stream=True)
+        iterator = iter(response)
+
+        result1 = repr(response)
+        expected1 = textwrap.dedent(
+            """\
+            response:
+            GenerateContentResponse(
+                done=False,
+                iterator=<generator>,
+                result=glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'first'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}),
+                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'first'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})])
+            )"""
+        )
+        self.assertEqual(expected1, result1)
+
+        next(iterator)
+        result2 = repr(response)
+        expected2 = textwrap.dedent(
+            """\
+            response:
+            GenerateContentResponse(
+                done=False,
+                iterator=<generator>,
+                result=glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'first second'}], 'role': ''}, 'index': 0, 'citation_metadata': {'citation_sources': []}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}], 'prompt_feedback': {'block_reason': 0, 'safety_ratings': []}}),
+                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'first'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': ' second'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})])
+            )"""
+        )
+        self.assertEqual(expected2, result2)
+
+        next(iterator)
+        result3 = repr(response)
+        expected3 = textwrap.dedent(
+            """\
+            response:
+            GenerateContentResponse(
+                done=False,
+                iterator=<generator>,
+                result=glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'first second third'}], 'role': ''}, 'index': 0, 'citation_metadata': {'citation_sources': []}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}], 'prompt_feedback': {'block_reason': 0, 'safety_ratings': []}}),
+                chunks=iter([glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': 'first'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': ' second'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]}), glm.GenerateContentResponse({'candidates': [{'content': {'parts': [{'text': ' third'}], 'role': ''}, 'finish_reason': 0, 'safety_ratings': [], 'token_count': 0, 'grounding_attributions': []}]})])
+            )"""
+        )
+        self.assertEqual(expected3, result3)
+
 
 if __name__ == "__main__":
     absltest.main()


### PR DESCRIPTION
## Description of the change
Added a `__repr__` method to `GenerateContentResponse` and `ChatSession`. (WIP PR 🚧 for closes #173 )

## Motivation
Improve DX when debugging the code by being able to reproduce `response` and `chat` objects from the `repr` methods.

## Type of change
Feature request

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [ ] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [ ] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
