### PR TITLE
Add ability to configure timeouts

### DIFF
--- a/google/generativeai/answer.py
+++ b/google/generativeai/answer.py
@@ -20,6 +20,7 @@ import itertools
 from typing import Iterable, Union, Mapping, Optional, Any
 
 import google.ai.generativelanguage as glm
+from google.api_core import gapic_v1
 
 from google.generativeai.client import get_default_generative_client
 from google.generativeai import string_utils
@@ -165,6 +166,7 @@ def generate_answer(
     safety_settings: safety_types.SafetySettingOptions | None = None,
     temperature: float | None = None,
     client: glm.GenerativeServiceClient | None = None,
+    timeout: Union[float, object] = gapic_v1.method.DEFAULT,
 ):
     """
     Calls the API and returns a `types.Answer` containing the answer.
@@ -193,6 +195,6 @@ def generate_answer(
         answer_style=answer_style,
     )
 
-    response = client.generate_answer(request)
+    response = client.generate_answer(request, timeout=timeout)
 
     return response

--- a/google/generativeai/embedding.py
+++ b/google/generativeai/embedding.py
@@ -20,6 +20,7 @@ import itertools
 from typing import Iterable, overload, TypeVar, Union, Mapping
 
 import google.ai.generativelanguage as glm
+from google.api_core import gapic_v1
 
 from google.generativeai.client import get_default_generative_client
 from google.generativeai.client import get_default_generative_async_client
@@ -95,6 +96,7 @@ def embed_content(
     task_type: EmbeddingTaskTypeOptions | None = None,
     title: str | None = None,
     client: glm.GenerativeServiceClient | None = None,
+    timeout: Union[float, object] = gapic_v1.method.DEFAULT,
 ) -> text_types.EmbeddingDict: ...
 
 
@@ -105,6 +107,7 @@ def embed_content(
     task_type: EmbeddingTaskTypeOptions | None = None,
     title: str | None = None,
     client: glm.GenerativeServiceClient | None = None,
+    timeout: Union[float, object] = gapic_v1.method.DEFAULT,
 ) -> text_types.BatchEmbeddingDict: ...
 
 
@@ -114,6 +117,7 @@ def embed_content(
     task_type: EmbeddingTaskTypeOptions | None = None,
     title: str | None = None,
     client: glm.GenerativeServiceClient = None,
+    timeout: Union[float, object] = gapic_v1.method.DEFAULT,
 ) -> text_types.EmbeddingDict | text_types.BatchEmbeddingDict:
     """Calls the API to create embeddings for content passed in.
 
@@ -160,7 +164,10 @@ def embed_content(
         )
         for batch in _batched(requests, EMBEDDING_MAX_BATCH_SIZE):
             embedding_request = glm.BatchEmbedContentsRequest(model=model, requests=batch)
-            embedding_response = client.batch_embed_contents(embedding_request)
+            embedding_response = client.batch_embed_contents(
+                embedding_request,
+                timeout=timeout,
+            )
             embedding_dict = type(embedding_response).to_dict(embedding_response)
             result["embedding"].extend(e["values"] for e in embedding_dict["embeddings"])
         return result
@@ -168,7 +175,10 @@ def embed_content(
         embedding_request = glm.EmbedContentRequest(
             model=model, content=content_types.to_content(content), task_type=task_type, title=title
         )
-        embedding_response = client.embed_content(embedding_request)
+        embedding_response = client.embed_content(
+            embedding_request,
+            timeout=timeout,
+        )
         embedding_dict = type(embedding_response).to_dict(embedding_response)
         embedding_dict["embedding"] = embedding_dict["embedding"]["values"]
         return embedding_dict

--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -11,6 +11,7 @@ from typing import Union
 
 
 from google.ai import generativelanguage as glm
+from google.api_core import gapic_v1
 from google.generativeai import client
 from google.generativeai import string_utils
 from google.generativeai.types import content_types
@@ -138,6 +139,7 @@ class GenerativeModel:
         generation_config: generation_types.GenerationConfigType | None = None,
         safety_settings: safety_types.SafetySettingOptions | None = None,
         stream: bool = False,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
         **kwargs,
     ) -> generation_types.GenerateContentResponse:
         """A multipurpose function to generate responses from the model.
@@ -204,10 +206,10 @@ class GenerativeModel:
 
         if stream:
             with generation_types.rewrite_stream_error():
-                iterator = self._client.stream_generate_content(request)
+                iterator = self._client.stream_generate_content(request, timeout=timeout)
             return generation_types.GenerateContentResponse.from_iterator(iterator)
         else:
-            response = self._client.generate_content(request)
+            response = self._client.generate_content(request, timeout=timeout)
             return generation_types.GenerateContentResponse.from_response(response)
 
     async def generate_content_async(
@@ -217,6 +219,7 @@ class GenerativeModel:
         generation_config: generation_types.GenerationConfigType | None = None,
         safety_settings: safety_types.SafetySettingOptions | None = None,
         stream: bool = False,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
         **kwargs,
     ) -> generation_types.AsyncGenerateContentResponse:
         """The async version of `GenerativeModel.generate_content`."""
@@ -231,28 +234,41 @@ class GenerativeModel:
 
         if stream:
             with generation_types.rewrite_stream_error():
-                iterator = await self._async_client.stream_generate_content(request)
+                iterator = await self._async_client.stream_generate_content(
+                    request, timeout=timeout
+                )
             return await generation_types.AsyncGenerateContentResponse.from_aiterator(iterator)
         else:
-            response = await self._async_client.generate_content(request)
+            response = await self._async_client.generate_content(request, timeout=timeout)
             return generation_types.AsyncGenerateContentResponse.from_response(response)
 
     # fmt: off
     def count_tokens(
-        self, contents: content_types.ContentsType
+        self,
+        contents: content_types.ContentsType,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
     ) -> glm.CountTokensResponse:
         if self._client is None:
             self._client = client.get_default_generative_client()
         contents = content_types.to_contents(contents)
-        return self._client.count_tokens(glm.CountTokensRequest(model=self.model_name, contents=contents))
+        return self._client.count_tokens(
+            glm.CountTokensRequest(model=self.model_name, contents=contents),
+            timeout=timeout,
+        )
 
     async def count_tokens_async(
-        self, contents: content_types.ContentsType
+        self,
+        contents: content_types.ContentsType,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
     ) -> glm.CountTokensResponse:
         if self._async_client is None:
             self._async_client = client.get_default_generative_async_client()
         contents = content_types.to_contents(contents)
-        return await self._async_client.count_tokens(glm.CountTokensRequest(model=self.model_name, contents=contents))
+        return await self._async_client.count_tokens(
+            glm.CountTokensRequest(model=self.model_name, contents=contents),
+            timeout=timeout,
+        )
+
     # fmt: on
 
     def start_chat(

--- a/tests/test_answer.py
+++ b/tests/test_answer.py
@@ -14,10 +14,12 @@
 # limitations under the License.
 import copy
 import math
+from typing import Union
 import unittest
 import unittest.mock as mock
 
 import google.ai.generativelanguage as glm
+from google.api_core import gapic_v1
 
 from google.generativeai import answer
 from google.generativeai import client
@@ -46,6 +48,7 @@ class UnitTests(parameterized.TestCase):
         @add_client_method
         def generate_answer(
             request: glm.GenerateAnswerRequest,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
         ) -> glm.GenerateAnswerResponse:
             self.observed_requests.append(request)
             return glm.GenerateAnswerResponse(

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -14,10 +14,12 @@
 # limitations under the License.
 import copy
 import math
+from typing import Union
 import unittest
 import unittest.mock as mock
 
 import google.ai.generativelanguage as glm
+from google.api_core import gapic_v1
 
 from google.generativeai import embedding
 
@@ -45,6 +47,7 @@ class UnitTests(parameterized.TestCase):
         @add_client_method
         def embed_content(
             request: glm.EmbedContentRequest,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
         ) -> glm.EmbedContentResponse:
             self.observed_requests.append(request)
             return glm.EmbedContentResponse(embedding=glm.ContentEmbedding(values=[1, 2, 3]))

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -2,10 +2,12 @@ import collections
 from collections.abc import Iterable
 import copy
 import pathlib
+from typing import Union
 import unittest.mock
 from absl.testing import absltest
 from absl.testing import parameterized
 import google.ai.generativelanguage as glm
+from google.api_core import gapic_v1
 from google.generativeai import client as client_lib
 from google.generativeai import generative_models
 from google.generativeai.types import content_types
@@ -42,6 +44,7 @@ class CUJTests(parameterized.TestCase):
         @add_client_method
         def generate_content(
             request: glm.GenerateContentRequest,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
         ) -> glm.GenerateContentResponse:
             self.assertIsInstance(request, glm.GenerateContentRequest)
             self.observed_requests.append(request)
@@ -51,6 +54,7 @@ class CUJTests(parameterized.TestCase):
         @add_client_method
         def stream_generate_content(
             request: glm.GetModelRequest,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
         ) -> Iterable[glm.GenerateContentResponse]:
             self.observed_requests.append(request)
             response = self.responses["stream_generate_content"].pop(0)
@@ -59,6 +63,7 @@ class CUJTests(parameterized.TestCase):
         @add_client_method
         def count_tokens(
             request: glm.CountTokensRequest,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
         ) -> Iterable[glm.GenerateContentResponse]:
             self.observed_requests.append(request)
             response = self.responses["count_tokens"].pop(0)

--- a/tests/test_generative_models_async.py
+++ b/tests/test_generative_models_async.py
@@ -17,7 +17,10 @@ import collections
 import sys
 from collections.abc import Iterable
 import os
+from typing import Union
 import unittest
+
+from google.api_core import gapic_v1
 
 from google.generativeai import client as client_lib
 from google.generativeai import generative_models
@@ -48,6 +51,7 @@ class AsyncTests(parameterized.TestCase, unittest.IsolatedAsyncioTestCase):
         @add_client_method
         async def generate_content(
             request: glm.GenerateContentRequest,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
         ) -> glm.GenerateContentResponse:
             self.assertIsInstance(request, glm.GenerateContentRequest)
             self.observed_requests.append(request)
@@ -57,6 +61,7 @@ class AsyncTests(parameterized.TestCase, unittest.IsolatedAsyncioTestCase):
         @add_client_method
         async def stream_generate_content(
             request: glm.GetModelRequest,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
         ) -> Iterable[glm.GenerateContentResponse]:
             self.observed_requests.append(request)
             response = self.responses["stream_generate_content"].pop(0)


### PR DESCRIPTION
## Description of the change
Added a `timeout` kwarg to relevant methods where it can be used (closes #182)

Methods extended with timeout kwarg:
- `generate_answer`
- `embed_content`
- `generate_content`
- `generate_content_async`

## Motivation
Makes it possible to wait for the response longer, for example if the number of tokens is large, or the payload has multiple files/images. The default behavior is to stop after 60 seconds and the current API doesn't allow to change it (see default value [here](https://github.com/googleapis/google-cloud-python/blob/b985096d43add8214172ff993e00293e6c8757cb/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/base.py#L130-L143)).

## Type of change
Feature request

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [ ] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [ ] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
