### PR TITLE
Throws exception if api key is empty

### DIFF
--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -216,7 +216,6 @@ def configure(
 
 
 _client_manager = _ClientManager()
-_client_manager.configure()
 
 def get_default_discuss_client() -> glm.DiscussServiceClient:
     return _client_manager.get_default_client("discuss")

--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -80,8 +80,8 @@ class _ClientManager:
                 # If no key is provided explicitly, attempt to load one from the
                 # environment.
                 api_key = os.getenv("GOOGLE_API_KEY", "")
-                if api_key == "":
-                    raise ValueError("api key must not be empty.")
+            if api_key == "":
+                raise ValueError("api key must not be empty.")
 
             client_options.api_key = api_key
 

--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -82,7 +82,7 @@ class _ClientManager:
                 api_key = os.getenv("GOOGLE_API_KEY", "")
                 if api_key == "":
                     raise ValueError("api key must not be empty.")
-            
+
             client_options.api_key = api_key
 
         user_agent = f"{USER_AGENT}/{__version__}"

--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -79,8 +79,10 @@ class _ClientManager:
             if api_key is None:
                 # If no key is provided explicitly, attempt to load one from the
                 # environment.
-                api_key = os.getenv("GOOGLE_API_KEY")
-
+                api_key = os.getenv("GOOGLE_API_KEY", "")
+                if api_key == "":
+                    raise ValueError("api key must not be empty.")
+            
             client_options.api_key = api_key
 
         user_agent = f"{USER_AGENT}/{__version__}"
@@ -214,7 +216,6 @@ def configure(
 
 
 _client_manager = _ClientManager()
-_client_manager.configure()
 
 
 def get_default_discuss_client() -> glm.DiscussServiceClient:

--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -216,7 +216,7 @@ def configure(
 
 
 _client_manager = _ClientManager()
-
+_client_manager.configure()
 
 def get_default_discuss_client() -> glm.DiscussServiceClient:
     return _client_manager.get_default_client("discuss")

--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -80,6 +80,7 @@ class _ClientManager:
                 # If no key is provided explicitly, attempt to load one from the
                 # environment.
                 api_key = os.getenv("GOOGLE_API_KEY", "")
+            # if api_key is empty string, raise exception.
             if api_key == "":
                 raise ValueError("api key can't be empty.")
 

--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -218,6 +218,7 @@ def configure(
 
 _client_manager = _ClientManager()
 
+
 def get_default_discuss_client() -> glm.DiscussServiceClient:
     return _client_manager.get_default_client("discuss")
 

--- a/google/generativeai/client.py
+++ b/google/generativeai/client.py
@@ -81,7 +81,7 @@ class _ClientManager:
                 # environment.
                 api_key = os.getenv("GOOGLE_API_KEY", "")
             if api_key == "":
-                raise ValueError("api key must not be empty.")
+                raise ValueError("api key can't be empty.")
 
             client_options.api_key = api_key
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,0 @@
-import os
-os.environ['GOOGLE_API_KEY'] = 'AIzA_env'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+import os
+os.environ['GOOGLE_API_KEY'] = 'AIzA_env'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,7 +43,7 @@ class ClientTests(parameterized.TestCase):
     def test_api_key_cannot_be_empty(self):
         with self.assertRaisesRegex(ValueError, "api key must not be empty"):
             client.configure()
-    
+
     def test_api_key_cannot_be_set_twice(self):
         client_opts = client_options.ClientOptions(api_key="AIzA_client_opts")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,11 +43,6 @@ class ClientTests(parameterized.TestCase):
         with self.assertRaisesRegex(ValueError, "api key can't be empty."):
             client.configure(api_key="")
     
-    def test_api_key_cannot_be_empty_passed_via_client_options(self):
-        with self.assertRaisesRegex(ValueError, "api key can't be empty."):
-            client_opts = client_options.ClientOptions(api_key="")
-            client.configure(client_options=client_opts)
-
     @mock.patch.dict(os.environ, {"GOOGLE_API_KEY": ""})
     def test_api_key_cannot_be_empty_from_environment(self):
         with self.assertRaisesRegex(ValueError, "api key can't be empty."):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -39,6 +39,11 @@ class ClientTests(parameterized.TestCase):
         client_opts = client._client_manager.client_config["client_options"]
         self.assertEqual(client_opts.api_key, "AIzA_client")
 
+    @mock.patch.dict(os.environ, {"GOOGLE_API_KEY": ""})
+    def test_api_key_cannot_be_empty(self):
+        with self.assertRaisesRegex(ValueError, "api key must not be empty"):
+            client.configure()
+    
     def test_api_key_cannot_be_set_twice(self):
         client_opts = client_options.ClientOptions(api_key="AIzA_client_opts")
 
@@ -91,6 +96,7 @@ class ClientTests(parameterized.TestCase):
             cls.called_classm = True
 
     @mock.patch.object(glm, "TextServiceClient", DummyClient)
+    @mock.patch.dict(os.environ, {"GOOGLE_API_KEY": "AIzA_env"})
     def test_default_metadata(self):
         # The metadata wrapper injects this argument.
         metadata = [("hello", "world")]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -38,11 +38,11 @@ class ClientTests(parameterized.TestCase):
         client.configure(api_key="AIzA_client")
         client_opts = client._client_manager.client_config["client_options"]
         self.assertEqual(client_opts.api_key, "AIzA_client")
-    
+
     def test_api_key_cannot_be_empty_passed_directly(self):
         with self.assertRaisesRegex(ValueError, "api key can't be empty."):
             client.configure(api_key="")
-    
+
     @mock.patch.dict(os.environ, {"GOOGLE_API_KEY": ""})
     def test_api_key_cannot_be_empty_from_environment(self):
         with self.assertRaisesRegex(ValueError, "api key can't be empty."):
@@ -59,7 +59,7 @@ class ClientTests(parameterized.TestCase):
     def test_configureless_client_with_empty_api_key(self, factory_fn):
         with self.assertRaisesRegex(ValueError, "api key can't be empty."):
             _ = factory_fn()
-    
+
     def test_empty_api_key_cannot_be_set_twice(self):
         client_opts = client_options.ClientOptions(api_key="")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -118,6 +118,7 @@ class ClientTests(parameterized.TestCase):
             cls.called_classm = True
 
     @mock.patch.object(glm, "TextServiceClient", DummyClient)
+    @mock.patch.dict(os.environ, {"GOOGLE_API_KEY": "AIzA_env"})
     def test_default_metadata(self):
         # The metadata wrapper injects this argument.
         metadata = [("hello", "world")]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -118,7 +118,6 @@ class ClientTests(parameterized.TestCase):
             cls.called_classm = True
 
     @mock.patch.object(glm, "TextServiceClient", DummyClient)
-    @mock.patch.dict(os.environ, {"GOOGLE_API_KEY": "AIzA_env"})
     def test_default_metadata(self):
         # The metadata wrapper injects this argument.
         metadata = [("hello", "world")]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -40,17 +40,17 @@ class ClientTests(parameterized.TestCase):
         self.assertEqual(client_opts.api_key, "AIzA_client")
     
     def test_api_key_cannot_be_empty_passed_directly(self):
-        with self.assertRaisesRegex(ValueError, "api key must not be empty"):
+        with self.assertRaisesRegex(ValueError, "api key can't be empty."):
             client.configure(api_key="")
     
     def test_api_key_cannot_be_empty_passed_via_client_options(self):
-        with self.assertRaisesRegex(ValueError, "api key must not be empty"):
+        with self.assertRaisesRegex(ValueError, "api key can't be empty."):
             client_opts = client_options.ClientOptions(api_key="")
             client.configure(client_options=client_opts)
 
     @mock.patch.dict(os.environ, {"GOOGLE_API_KEY": ""})
     def test_api_key_cannot_be_empty_from_environment(self):
-        with self.assertRaisesRegex(ValueError, "api key must not be empty"):
+        with self.assertRaisesRegex(ValueError, "api key can't be empty."):
             client.configure()
 
     @parameterized.parameters(
@@ -62,13 +62,13 @@ class ClientTests(parameterized.TestCase):
     )
     @mock.patch.dict(os.environ, {"GOOGLE_API_KEY": ""})
     def test_configureless_client_with_empty_api_key(self, factory_fn):
-        with self.assertRaisesRegex(ValueError, "api key must not be empty"):
+        with self.assertRaisesRegex(ValueError, "api key can't be empty."):
             _ = factory_fn()
     
     def test_empty_api_key_cannot_be_set_twice(self):
         client_opts = client_options.ClientOptions(api_key="")
 
-        with self.assertRaisesRegex(ValueError, "api key must not be empty."):
+        with self.assertRaisesRegex(ValueError, "api key can't be empty."):
             client.configure(api_key="", client_options=client_opts)
 
     def test_api_key_cannot_be_set_twice(self):


### PR DESCRIPTION
## Description of the change
The code has been updated to throw an exception if either the api_key argument is not set or GOOGLE_API_KEY environment is not set.


## Motivation
<!--- Why is this change required? What problem does it solve? Please include the corresponding issue number/link if applicable. -->
The following sample code takes approximately 50 seconds to execute and return a response.
The reason for this is that if the api_key is not set, `configure` method will set it to None. If an incorrect `api_key` is set, an error will be returned immediately, but if it is `None`, the exception response will be slow. 
exception should be raised if the `api_key` is an empty string.
<details><summary>sample code</summary><div>

```py
import google.generativeai as genai
import os
import time

start_time = time.time()
try:
    model = genai.GenerativeModel('gemini-pro')
    response = model.generate_content("The opposite of hot is")
    print(response.text)
except Exception as e:
    end_time = time.time()
    done = end_time - start_time
    print(f"proccess time {done}")
    print(e)
# output: proccess time 59.70200800895691
```
</div></details>

The reason for removing `_client.configure()` in client.py is that when calling APIs such as generative or embed, if client is None, the client will be acquired by default. 
`client is None`: 
[generate answer](https://github.com/google/generative-ai-python/blob/4f1ea10a0cc40ce53c142d4878f4852bb1d05d1e/google/generativeai/answer.py#L189),[discuss](https://github.com/google/generative-ai-python/blob/4f1ea10a0cc40ce53c142d4878f4852bb1d05d1e/google/generativeai/discuss.py#L545), [embed_content](https://github.com/google/generative-ai-python/blob/4f1ea10a0cc40ce53c142d4878f4852bb1d05d1e/google/generativeai/embedding.py#L150), [generative model](https://github.com/google/generative-ai-python/blob/4f1ea10a0cc40ce53c142d4878f4852bb1d05d1e/google/generativeai/generative_models.py#L218), [model](https://github.com/google/generative-ai-python/blob/4f1ea10a0cc40ce53c142d4878f4852bb1d05d1e/google/generativeai/models.py#L86),[text](https://github.com/google/generative-ai-python/blob/4f1ea10a0cc40ce53c142d4878f4852bb1d05d1e/google/generativeai/text.py#L237)

## Type of change
Choose one: Feature request

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
