### PR TITLE
Critical Bugfix: send_message_async method should call the asynchronous method…

### DIFF
--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -534,7 +534,7 @@ class ChatSession:
         if generation_config.get("candidate_count", 1) > 1:
             raise ValueError("Can't chat with `candidate_count > 1`")
 
-        response = await self.model.generate_content(
+        response = await self.model.generate_content_async(
             contents=history,
             generation_config=generation_config,
             safety_settings=safety_settings,


### PR DESCRIPTION
… generate_content_async

## Description of the change
Use model.generate_content_async instead of self.model.generate_content in send_message_async 


## Motivation
There is obvious bug, resulting in broken async chat functionality.
Using the send_message_async method causes an error: object GenerateContentResponse can't be used in 'await' expression.

This PR is actually contains the same changes as https://github.com/google/generative-ai-python/pull/229, which still hasn't been merged because @xnny hasn't signed the agreement yet.

I'm creating this PR to do everything possible to have this fix in the main branch and the PyPI package as soon as possible because I really need it to include Gemini as an LLM option in the upcoming release of our software. Unfortunately, using the sync function or direct usage of the REST API is not an option at this point.

I would be very grateful if it were possible not only to merge this bugfix but also to release it on PyPI soon 🙏
Thanks.

## Type of change
Bug fix

## Checklist

- I have performed a self-review of my code.
- I have added detailed comments to my code where applicable.
- I have verified that my change does not break existing code.
- My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
