### PR TITLE
Fix incorrect reference to self.candidates[0].parts, self.candidates[0].parts[0].text

### DIFF
--- a/google/generativeai/types/generation_types.py
+++ b/google/generativeai/types/generation_types.py
@@ -301,7 +301,7 @@ class BaseGenerateContentResponse:
 
     @property
     def parts(self):
-        """A quick accessor equivalent to `self.candidates[0].parts`
+        """A quick accessor equivalent to `self.candidates[0].content.parts`
 
         Raises:
             ValueError: If the candidate list does not contain exactly one candidate.
@@ -323,7 +323,7 @@ class BaseGenerateContentResponse:
 
     @property
     def text(self):
-        """A quick accessor equivalent to `self.candidates[0].parts[0].text`
+        """A quick accessor equivalent to `self.candidates[0].content.parts[0].text`
 
         Raises:
             ValueError: If the candidate list or parts list does not contain exactly one entry.


### PR DESCRIPTION
Fix incorrect reference to self.candidates[0].parts, self.candidates[0].parts[0].text

#234 
## Description of the change
<!--- Describe your changes in detail. -->
self.candidates[0].parts to self.candidates[0].content.parts
self.candidates[0].parts[0].text to self.candidates[0].content.parts[0].text
## Motivation
<!--- Why is this change required? What problem does it solve? Please include the corresponding issue number/link if applicable. -->
miss leading
## Type of change
Choose one: (Bug fix | Feature request | Documentation | Other)

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
