### PR TITLE
Sdk update to use glm 0.6.1

### DIFF
--- a/google/generativeai/answer.py
+++ b/google/generativeai/answer.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 import dataclasses
 from collections.abc import Iterable
 import itertools
-from typing import Any, Iterable, Union, Mapping, Optional, TypedDict
+from typing import Any, Iterable, Union, Mapping, Optional
+from typing_extensions import TypedDict
 
 import google.ai.generativelanguage as glm
 

--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -155,7 +155,7 @@ class GenerativeModel:
             safety_settings=merged_ss,
             tools=tools_lib,
             tool_config=tool_config,
-            system_instructions=self._system_instructions,
+            system_instruction=self._system_instructions,
         )
 
     def _get_tools_lib(

--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -74,7 +74,7 @@ class GenerativeModel:
         generation_config: generation_types.GenerationConfigType | None = None,
         tools: content_types.FunctionLibraryType | None = None,
         tool_config: content_types.ToolConfigType | None = None,
-        system_instructions: content_types.ContentType | None = None,
+        system_instruction: content_types.ContentType | None = None,
     ):
         if "/" not in model_name:
             model_name = "models/" + model_name
@@ -90,10 +90,10 @@ class GenerativeModel:
         else:
             self._tool_config = content_types.to_tool_config(tool_config)
 
-        if system_instructions is None:
-            self._system_instructions = None
+        if system_instruction is None:
+            self._system_instruction = None
         else:
-            self._system_instructions = content_types.to_content(system_instructions)
+            self._system_instruction = content_types.to_content(system_instruction)
 
         self._client = None
         self._async_client = None
@@ -155,7 +155,7 @@ class GenerativeModel:
             safety_settings=merged_ss,
             tools=tools_lib,
             tool_config=tool_config,
-            system_instruction=self._system_instructions,
+            system_instruction=self._system_instruction,
         )
 
     def _get_tools_lib(

--- a/google/generativeai/types/content_types.py
+++ b/google/generativeai/types/content_types.py
@@ -712,7 +712,8 @@ def to_function_calling_config(obj: FunctionCallingConfigType) -> glm.FunctionCa
         obj["mode"] = to_function_calling_mode(mode)
     else:
         raise TypeError(
-            f"Could not convert input to `glm.FunctionCallingConfig`: \n'" f"  type: {type(obj)}\n", obj
+            f"Could not convert input to `glm.FunctionCallingConfig`: \n'" f"  type: {type(obj)}\n",
+            obj,
         )
 
     return glm.FunctionCallingConfig(obj)

--- a/google/generativeai/types/content_types.py
+++ b/google/generativeai/types/content_types.py
@@ -702,19 +702,9 @@ FunctionCallingConfigType = Union[FunctionCallingConfigDict, glm.FunctionCalling
 
 
 def to_function_calling_config(obj: FunctionCallingConfigType) -> glm.FunctionCallingConfig:
-    if isinstance(obj, glm.FunctionCallingConfig):
-        return obj
-    elif isinstance(obj, (FunctionCallingMode, str, int)):
+    if isinstance(obj, (FunctionCallingMode, str, int)):
         obj = {"mode": to_function_calling_mode(obj)}
-    elif isinstance(obj, dict):
-        obj = obj.copy()
-        mode = obj.pop("mode")
-        obj["mode"] = to_function_calling_mode(mode)
-    else:
-        raise TypeError(
-            f"Could not convert input to `glm.FunctionCallingConfig`: \n'" f"  type: {type(obj)}\n",
-            obj,
-        )
+
 
     return glm.FunctionCallingConfig(obj)
 

--- a/google/generativeai/types/content_types.py
+++ b/google/generativeai/types/content_types.py
@@ -702,8 +702,18 @@ FunctionCallingConfigType = Union[FunctionCallingConfigDict, glm.FunctionCalling
 
 
 def to_function_calling_config(obj: FunctionCallingConfigType) -> glm.FunctionCallingConfig:
-    if isinstance(obj, (FunctionCallingMode, str, int)):
+    if isinstance(obj, glm.FunctionCallingConfig):
+        return obj
+    elif isinstance(obj, (FunctionCallingMode, str, int)):
         obj = {"mode": to_function_calling_mode(obj)}
+    elif isinstance(obj, dict):
+        obj = obj.copy()
+        mode = obj.pop("mode")
+        obj["mode"] = to_function_calling_mode(mode)
+    else:
+        raise TypeError(
+            f"Could not convert input to `glm.FunctionCallingConfig`: \n'" f"  type: {type(obj)}\n", obj
+        )
 
     return glm.FunctionCallingConfig(obj)
 

--- a/google/generativeai/types/content_types.py
+++ b/google/generativeai/types/content_types.py
@@ -705,7 +705,6 @@ def to_function_calling_config(obj: FunctionCallingConfigType) -> glm.FunctionCa
     if isinstance(obj, (FunctionCallingMode, str, int)):
         obj = {"mode": to_function_calling_mode(obj)}
 
-
     return glm.FunctionCallingConfig(obj)
 
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-ai-generativelanguage@https://storage.googleapis.com/generativeai-downloads/preview/ai-generativelanguage-v1beta-py.tar.gz",
+    "google-ai-generativelanguage==0.6.1",
     "google-api-core",
     "google-api-python-client",
     "google-auth>=2.15.0",  # 2.15 adds API key auth support

--- a/tests/test_typing_extensions.py
+++ b/tests/test_typing_extensions.py
@@ -33,7 +33,7 @@ class TypingExtensionsTests(absltest.TestCase):
 
     def test_no_typing_typed_dict(self):
         root = pathlib.Path(__file__).parent.parent
-        for fpath in root.rglob("*.py"):
+        for fpath in (root / 'google').rglob("*.py"):
             source = fpath.read_text()
             if match := TYPING_RE.search(source):
                 raise ValueError(

--- a/tests/test_typing_extensions.py
+++ b/tests/test_typing_extensions.py
@@ -33,7 +33,7 @@ class TypingExtensionsTests(absltest.TestCase):
 
     def test_no_typing_typed_dict(self):
         root = pathlib.Path(__file__).parent.parent
-        for fpath in (root / 'google').rglob("*.py"):
+        for fpath in (root / "google").rglob("*.py"):
             source = fpath.read_text()
             if match := TYPING_RE.search(source):
                 raise ValueError(


### PR DESCRIPTION
1. Update dependency of `glm` package to use [`0.6.1`](https://github.com/googleapis/google-cloud-python/releases/tag/google-ai-generativelanguage-v0.6.1).
2. proto def for `GenerateContentRequest` lists `system_instruction` in singular as the field is not repeated. This is consistent with the latest release(glm==0.6.1)
3. Import `TypedDict` from `typing_extensions`


## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-python/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
