### PR TITLE
Add `system_instruction` to model repr

### DIFF
--- a/google/generativeai/generative_models.py
+++ b/google/generativeai/generative_models.py
@@ -103,6 +103,11 @@ class GenerativeModel:
         return self._model_name
 
     def __str__(self):
+        def maybe_text(content):
+            if content and len(content.parts) and (t := content.parts[0].text):
+                return repr(t)
+            return content
+
         return textwrap.dedent(
             f"""\
             genai.GenerativeModel(
@@ -110,6 +115,7 @@ class GenerativeModel:
                 generation_config={self._generation_config},
                 safety_settings={self._safety_settings},
                 tools={self._tools},
+                system_instruction={maybe_text(self._system_instruction)},
             )"""
         )
 

--- a/tests/test_generative_models.py
+++ b/tests/test_generative_models.py
@@ -913,6 +913,7 @@ class CUJTests(parameterized.TestCase):
                     generation_config={},
                     safety_settings={},
                     tools=None,
+                    system_instruction=None,
                 ),
                 history=[glm.Content({'parts': [{'text': 'I really like fantasy books.'}], 'role': 'user'}), glm.Content({'parts': [{'text': 'first'}], 'role': 'model'}), glm.Content({'parts': [{'text': 'I also like this image.'}, {'inline_data': {'data': 'iVBORw0KGgoA...AAElFTkSuQmCC', 'mime_type': 'image/png'}}], 'role': 'user'}), glm.Content({'parts': [{'text': 'second'}], 'role': 'model'}), glm.Content({'parts': [{'text': 'What things do I like?.'}], 'role': 'user'}), glm.Content({'parts': [{'text': 'third'}], 'role': 'model'})]
             )"""
@@ -940,6 +941,7 @@ class CUJTests(parameterized.TestCase):
                     generation_config={},
                     safety_settings={},
                     tools=None,
+                    system_instruction=None,
                 ),
                 history=[glm.Content({'parts': [{'text': 'I really like fantasy books.'}], 'role': 'user'}), <STREAMING IN PROGRESS>]
             )"""
@@ -983,11 +985,17 @@ class CUJTests(parameterized.TestCase):
                     generation_config={},
                     safety_settings={},
                     tools=None,
+                    system_instruction=None,
                 ),
                 history=[glm.Content({'parts': [{'text': 'I really like fantasy books.'}], 'role': 'user'}), <STREAMING ERROR>]
             )"""
         )
         self.assertEqual(expected, result)
+
+    def test_repr_for_system_instruction(self):
+        model = generative_models.GenerativeModel("gemini-pro", system_instruction="Be excellent.")
+        result = repr(model)
+        self.assertIn("system_instruction='Be excellent.'", result)
 
     def test_count_tokens_called_with_request_options(self):
         self.client.count_tokens = unittest.mock.MagicMock()


### PR DESCRIPTION
## Description of the change
Add `system_instruction` to the repr of  `GenerativeModel`

## Motivation
Model repr has all the fields set at construction-time. sysint should be there too.